### PR TITLE
Add ValidableResourceEngine

### DIFF
--- a/nap/engine.py
+++ b/nap/engine.py
@@ -2,7 +2,7 @@ import copy
 import json
 
 from .collection import ListWithAttributes
-from .exceptions import InvalidStatusError
+from .exceptions import InvalidStatusError, NapValidationException
 from .http import NapRequest, NapResponse
 from .serializers import JSONSerializer
 from .utils import handle_slash, make_url
@@ -521,10 +521,6 @@ class ResourceEngine(object):
 
         full_url = "%s%s" % (root_url, uri)
         return full_url
-
-
-class NapValidationException(Exception):
-    pass
 
 
 class ValidableResourceEngine(ResourceEngine):

--- a/nap/exceptions.py
+++ b/nap/exceptions.py
@@ -17,3 +17,7 @@ class EmptyResponseError(Exception):
 
 class DoesNotExist(Exception):
     pass
+
+
+class NapValidationException(Exception):
+    pass

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -6,8 +6,8 @@ import mock
 
 import nap
 from nap.http import NapResponse
-from nap.engine import ResourceEngine, ValidableResourceEngine, NapValidationException
-from nap.exceptions import InvalidStatusError
+from nap.engine import ResourceEngine, ValidableResourceEngine
+from nap.exceptions import InvalidStatusError, NapValidationException
 
 from . import SampleResourceModel
 


### PR DESCRIPTION
Add ValidableResourceEngine, NapValidationException, and unit tests under TestValidableResourceEngine to allow for server side validation errors to pass through with the correct status codes.

This code was originally written for CashStar's account_service, but was written in the Nap style and easily ported. Once merged, this new engine will be usable for other applications other than account_service.
