### PR TITLE
Pop root_url and set to meta

### DIFF
--- a/nap/resources.py
+++ b/nap/resources.py
@@ -59,7 +59,7 @@ class ResourceModel(object):
     def __init__(self, *args, **kwargs):
         """Construct a new model instance
         """
-        self._root_url = kwargs.get('root_url', self._meta['root_url'])
+        self._meta['root_url'] = self._root_url = kwargs.pop('root_url', self._meta['root_url'])
         self._request_args = kwargs.pop('request_args', {})
 
         self._saved = False

--- a/nap/resources.py
+++ b/nap/resources.py
@@ -59,7 +59,7 @@ class ResourceModel(object):
     def __init__(self, *args, **kwargs):
         """Construct a new model instance
         """
-        self._meta['root_url'] = self._root_url = kwargs.pop('root_url', self._meta['root_url'])
+        self._meta['root_url'] = kwargs.pop('root_url', self._meta['root_url'])
         self._request_args = kwargs.pop('request_args', {})
 
         self._saved = False

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -46,7 +46,7 @@ class TestResourceModelCreation(object):
 
         different_url = "http://www.differenturl.com/v1/"
         dm = SampleResourceModel(root_url=different_url)
-        assert dm._root_url == different_url
+        assert dm._meta['root_url'] == different_url
 
 
 class TestResourceSave(object):
@@ -196,27 +196,17 @@ class TestRootURLPop(object):
             root_url=some_url,
             content='Blank Content')
 
-        assert dm1._root_url == some_url
         assert dm1._meta['root_url'] == some_url
-        attribute_error = False
-        try:
+        with pytest.raises(AttributeError):
             dm1.root_url
-        except AttributeError:
-            attribute_error = True
-        assert attribute_error
 
         # After the first creation I shouldn't have to set the root url again
         dm2 = SampleResourceModel(
             content='Blank Content')
 
-        assert dm2._root_url == some_url
         assert dm2._meta['root_url'] == some_url
-        attribute_error = False
-        try:
+        with pytest.raises(AttributeError):
             dm2.root_url
-        except AttributeError:
-            attribute_error = True
-        assert attribute_error
 
         # If the root url gets set to something else now it should hold
         different_url = "http://www.differenturl.com/v1/"
@@ -224,11 +214,6 @@ class TestRootURLPop(object):
             root_url=different_url,
             content='Blank Content')
 
-        assert dm3._root_url == different_url
         assert dm3._meta['root_url'] == different_url
-        attribute_error = False
-        try:
+        with pytest.raises(AttributeError):
             dm3.root_url
-        except AttributeError:
-            attribute_error = True
-        assert attribute_error

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -190,16 +190,45 @@ class TestResourceShortcutMethods(object):
 class TestRootURLPop(object):
 
     def test_resource_id_get(self):
+        # Create resource with some url
+        some_url = "http://www.someurl.com/v1/"
+        dm1 = SampleResourceModel(
+            root_url=some_url,
+            content='Blank Content')
+
+        assert dm1._root_url == some_url
+        assert dm1._meta['root_url'] == some_url
+        attribute_error = False
+        try:
+            dm1.root_url
+        except AttributeError:
+            attribute_error = True
+        assert attribute_error
+
+        # After the first creation I shouldn't have to set the root url again
+        dm2 = SampleResourceModel(
+            content='Blank Content')
+
+        assert dm2._root_url == some_url
+        assert dm2._meta['root_url'] == some_url
+        attribute_error = False
+        try:
+            dm2.root_url
+        except AttributeError:
+            attribute_error = True
+        assert attribute_error
+
+        # If the root url gets set to something else now it should hold
         different_url = "http://www.differenturl.com/v1/"
-        dm = SampleResourceModel(
+        dm3 = SampleResourceModel(
             root_url=different_url,
             content='Blank Content')
 
-        assert dm._root_url == different_url
-        assert dm._meta['root_url'] == different_url
+        assert dm3._root_url == different_url
+        assert dm3._meta['root_url'] == different_url
         attribute_error = False
         try:
-            dm.root_url
+            dm3.root_url
         except AttributeError:
             attribute_error = True
         assert attribute_error

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -139,7 +139,7 @@ class TestReourceEtcMethods(object):
         assert dm != object()
 
     def test_cache_key_method(self):
-        dm = SampleResourceModel(slug='some-slug')
+        dm = SampleResourceModel(root_url="http://foo.com/v1/", slug='some-slug')
 
         assert dm.cache_key == "note::http://foo.com/v1/note/some-slug/"
 
@@ -185,3 +185,21 @@ class TestResourceShortcutMethods(object):
         obj.delete()
         eng_del.assert_called_with(obj)
         assert obj.resource_id is None
+
+
+class TestRootURLPop(object):
+
+    def test_resource_id_get(self):
+        different_url = "http://www.differenturl.com/v1/"
+        dm = SampleResourceModel(
+            root_url=different_url,
+            content='Blank Content')
+
+        assert dm._root_url == different_url
+        assert dm._meta['root_url'] == different_url
+        attribute_error = False
+        try:
+            dm.root_url
+        except AttributeError:
+            attribute_error = True
+        assert attribute_error


### PR DESCRIPTION
Making the nap base ResourceModel set the root_url from kwargs on the meta, following our ResourceModel2 functionality.  Relates to ticket INFR-1260

Hopefully to get some reviewers on this: @bbqbaron @cjcooper @afitzgerald @mpistrang @jbane 
