### PR TITLE
Make nap work with python2 or python3

### DIFF
--- a/docs/_ext/napdocs.py
+++ b/docs/_ext/napdocs.py
@@ -1,6 +1,7 @@
 """
 Sphinx plugins for nap documentation.
 """
+from __future__ import unicode_literals
 
 
 def setup(app):

--- a/docs/_themes/flask_theme_support.py
+++ b/docs/_themes/flask_theme_support.py
@@ -1,4 +1,5 @@
 # flasky extensions.  flasky pygments style based on tango style
+from __future__ import unicode_literals
 from pygments.style import Style
 from pygments.token import Keyword, Name, Comment, String, Error, \
      Number, Operator, Generic, Whitespace, Punctuation, Other, Literal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-
+from __future__ import unicode_literals
 import os
 import sys
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,8 +41,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'nap'
-copyright = u'2012, Jacob Burch'
+project = 'nap'
+copyright = '2012, Jacob Burch'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -191,8 +191,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'nap.tex', u'nap Documentation',
-   u'Jacob Burch', 'manual'),
+  ('index', 'nap.tex', 'nap Documentation',
+   'Jacob Burch', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -220,8 +220,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'nap', u'nap Documentation',
-     [u'Jacob Burch'], 1)
+    ('index', 'nap', 'nap Documentation',
+     ['Jacob Burch'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -234,8 +234,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'nap', u'nap Documentation',
-   u'Jacob Burch', 'nap', 'One line description of project.',
+  ('index', 'nap', 'nap Documentation',
+   'Jacob Burch', 'nap', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/examples/github_gist.py
+++ b/examples/github_gist.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import nap
 from nap.auth import FoauthAuthorization
 from nap.lookup import nap_url

--- a/examples/twitter.py
+++ b/examples/twitter.py
@@ -1,4 +1,6 @@
+from __future__ import unicode_literals
 import nap
+
 
 
 class User(nap.ResourceModel):

--- a/nap/__init__.py
+++ b/nap/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .fields import (Field, ResourceField, DictField, ListField, DateTimeField)
 from .lookup import nap_url
 from .resources import ResourceModel

--- a/nap/auth.py
+++ b/nap/auth.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import re
 from .middleware import BaseMiddleware
 

--- a/nap/auth.py
+++ b/nap/auth.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from __future__ import absolute_import
 import re
 from .middleware import BaseMiddleware
 

--- a/nap/cache/base.py
+++ b/nap/cache/base.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import re
 
 DEFAULT_TIMEOUT = 60 * 5

--- a/nap/cache/django_cache.py
+++ b/nap/cache/django_cache.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from __future__ import absolute_import
 try:
     from django.core.cache import cache
 except ImportError as e:

--- a/nap/cache/django_cache.py
+++ b/nap/cache/django_cache.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 try:
     from django.core.cache import cache
 except ImportError as e:

--- a/nap/collection.py
+++ b/nap/collection.py
@@ -1,4 +1,4 @@
-
+from __future__ import unicode_literals
 
 class ListWithAttributes(list):
     def __init__(self, list_vals, extra_data=None):

--- a/nap/conf.py
+++ b/nap/conf.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from __future__ import absolute_import
 """
 Kudos to mitsuhiko for flask's configuration for inspiring much of this
 """

--- a/nap/conf.py
+++ b/nap/conf.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 """
 Kudos to mitsuhiko for flask's configuration for inspiring much of this
 """

--- a/nap/engine.py
+++ b/nap/engine.py
@@ -74,7 +74,7 @@ class ResourceEngine(object):
             }
 
             url_match_vars = dict([
-                (k, v) for (k, v) in model_keywords.items()
+                (k, v) for (k, v) in list(model_keywords.items())
                 if k in url.url_vars
             ])
 

--- a/nap/engine.py
+++ b/nap/engine.py
@@ -1,18 +1,12 @@
 from __future__ import unicode_literals
 import copy
 import json
-import six
 
 from .collection import ListWithAttributes
 from .exceptions import InvalidStatusError, BadRequestError
 from .http import NapRequest, NapResponse
 from .serializers import JSONSerializer
-from .utils import handle_slash, make_url
-
-
-text_fn = str if six.PY3 else unicode
-def to_unicode(s):
-    return s if isinstance(s, six.text_type) else text_fn(s, 'utf-8')
+from .utils import handle_slash, make_url, to_unicode
 
 
 class ResourceEngine(object):

--- a/nap/engine.py
+++ b/nap/engine.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from __future__ import absolute_import
 import copy
 import json
 
@@ -75,7 +76,7 @@ class ResourceEngine(object):
             }
 
             url_match_vars = dict([
-                (k, v) for (k, v) in list(model_keywords.items())
+                (k, v) for (k, v) in model_keywords.items()
                 if k in url.url_vars
             ])
 

--- a/nap/engine.py
+++ b/nap/engine.py
@@ -199,7 +199,8 @@ class ResourceEngine(object):
         """Handle any actions needed after a HTTP Response has ben validated
         for a get (get, refresh, lookup) action
         """
-        resource_data = self.deserialize(response.content)
+        content_str = str(response.content, 'utf-8')
+        resource_data = self.deserialize(content_str)
 
         self._raw_response_content = resource_data
         self.handle_response(response)
@@ -236,7 +237,7 @@ class ResourceEngine(object):
         self.validate_collection_response(response)
 
         serializer = self.get_serializer()
-        r_data = serializer.deserialize(response.content)
+        r_data = serializer.deserialize(str(response.content, 'utf-8'))
         collection_field = self.model._meta.get('collection_field')
         if collection_field and collection_field in r_data:
             obj_list = r_data[collection_field]
@@ -290,7 +291,7 @@ class ResourceEngine(object):
         self.validate_response(response)
 
         if response.status_code in self.model._meta['bad_request_status']:
-            errors = json.loads(response.content)
+            errors = json.loads(str(response.content, 'utf-8'))
             raise BadRequestError(response, errors)
 
         if response.status_code not in self.model._meta['valid_update_status']:
@@ -351,7 +352,7 @@ class ResourceEngine(object):
         self.validate_response(response)
 
         if response.status_code in self.model._meta['bad_request_status']:
-            errors = json.loads(response.content)
+            errors = json.loads(str(response.content, 'utf-8'))
             raise BadRequestError(response, errors)
 
         if response.status_code not in self.model._meta['valid_create_status']:
@@ -445,7 +446,7 @@ class ResourceEngine(object):
         """
         obj = self.model()
         serializer = self.get_serializer()
-        field_data = serializer.deserialize(response.content)
+        field_data = serializer.deserialize(str(response.content, 'utf-8'))
         obj.update_fields(field_data)
         obj._full_url = response.url
 

--- a/nap/engine.py
+++ b/nap/engine.py
@@ -9,16 +9,10 @@ from .http import NapRequest, NapResponse
 from .serializers import JSONSerializer
 from .utils import handle_slash, make_url
 
-try:
-    from __builtin__ import unicode #py2
-except ImportError:
-    from __builtin__ import str as unicode #py3
 
-def to_unicode(text):
-    try:
-        return unicode(text, 'utf-8')
-    except TypeError:
-        return text
+text_fn = str if six.PY3 else unicode
+def to_unicode(s):
+    return s if isinstance(s, six.text_type) else text_fn(s, 'utf-8')
 
 
 class ResourceEngine(object):
@@ -212,7 +206,7 @@ class ResourceEngine(object):
         """Handle any actions needed after a HTTP Response has ben validated
         for a get (get, refresh, lookup) action
         """
-        content_str = unicode(response.content)
+        content_str = to_unicode(response.content)
         resource_data = self.deserialize(content_str)
 
         self._raw_response_content = resource_data

--- a/nap/exceptions.py
+++ b/nap/exceptions.py
@@ -1,4 +1,4 @@
-
+from __future__ import unicode_literals
 
 class InvalidStatusError(ValueError):
 

--- a/nap/fields.py
+++ b/nap/fields.py
@@ -196,7 +196,7 @@ class DictField(ResourceField):
             return {}
 
         resource_dict = dict([
-            (k, self.coerce(v)) for (k, v) in val.iteritems()
+            (k, self.coerce(v)) for (k, v) in val.items()
         ])
         return resource_dict
 
@@ -207,6 +207,6 @@ class DictField(ResourceField):
         if not val:
             return {}
         resource_dict = dict([
-            (k, v.to_python()) for (k, v) in val.iteritems()
+            (k, v.to_python()) for (k, v) in val.items()
         ])
         return resource_dict

--- a/nap/fields.py
+++ b/nap/fields.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from __future__ import absolute_import
 import datetime
 from decimal import Decimal
 

--- a/nap/fields.py
+++ b/nap/fields.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import datetime
 from decimal import Decimal
 

--- a/nap/http.py
+++ b/nap/http.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import requests
 
 

--- a/nap/lookup.py
+++ b/nap/lookup.py
@@ -1,7 +1,14 @@
 """
 Classes and functions for url resolving
 """
+from __future__ import unicode_literals
 import re
+import six
+
+try:
+    from __builtin__ import unicode #py2
+except ImportError:
+   from __builtin__ import str as unicode #py3
 
 
 class LookupURL(object):
@@ -50,7 +57,7 @@ class LookupURL(object):
 
         # etc
     def __unicode__(self):
-        return str(self.url_string)
+        return unicode(self.url_string)
 
     def __repr__(self):
         return "<%s: %s>" % (self.__class__.__name__, self.__unicode__())

--- a/nap/lookup.py
+++ b/nap/lookup.py
@@ -39,7 +39,7 @@ class LookupURL(object):
             return None, None
 
         extra_params = dict([
-            item for item in lookup_vars.items()
+            item for item in list(lookup_vars.items())
             if item[0] not in self.required_vars
         ])
 
@@ -50,7 +50,7 @@ class LookupURL(object):
 
         # etc
     def __unicode__(self):
-        return unicode(self.url_string)
+        return str(self.url_string)
 
     def __repr__(self):
         return "<%s: %s>" % (self.__class__.__name__, self.__unicode__())

--- a/nap/lookup.py
+++ b/nap/lookup.py
@@ -3,12 +3,7 @@ Classes and functions for url resolving
 """
 from __future__ import unicode_literals
 import re
-import six
-
-
-text_fn = str if six.PY3 else unicode
-def to_unicode(s):
-    return s if isinstance(s, six.text_type) else text_fn(s, 'utf-8')
+from .utils import to_unicode
 
 
 class LookupURL(object):

--- a/nap/lookup.py
+++ b/nap/lookup.py
@@ -2,6 +2,7 @@
 Classes and functions for url resolving
 """
 from __future__ import unicode_literals
+from __future__ import absolute_import
 import re
 from .utils import to_unicode
 
@@ -41,7 +42,7 @@ class LookupURL(object):
             return None, None
 
         extra_params = dict([
-            item for item in list(lookup_vars.items())
+            item for item in lookup_vars.items()
             if item[0] not in self.required_vars
         ])
 

--- a/nap/lookup.py
+++ b/nap/lookup.py
@@ -5,10 +5,10 @@ from __future__ import unicode_literals
 import re
 import six
 
-try:
-    from __builtin__ import unicode #py2
-except ImportError:
-   from __builtin__ import str as unicode #py3
+
+text_fn = str if six.PY3 else unicode
+def to_unicode(s):
+    return s if isinstance(s, six.text_type) else text_fn(s, 'utf-8')
 
 
 class LookupURL(object):
@@ -57,7 +57,7 @@ class LookupURL(object):
 
         # etc
     def __unicode__(self):
-        return unicode(self.url_string)
+        return to_unicode(self.url_string)
 
     def __repr__(self):
         return "<%s: %s>" % (self.__class__.__name__, self.__unicode__())

--- a/nap/middleware.py
+++ b/nap/middleware.py
@@ -1,4 +1,4 @@
-
+from __future__ import unicode_literals
 
 class BaseMiddleware(object):
 

--- a/nap/resources.py
+++ b/nap/resources.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from __future__ import absolute_import
 from .conf import NapConfig
 from .exceptions import EmptyResponseError
 from .fields import Field

--- a/nap/resources.py
+++ b/nap/resources.py
@@ -1,7 +1,15 @@
+from __future__ import unicode_literals
 from .conf import NapConfig
 from .exceptions import EmptyResponseError
 from .fields import Field
 from .lookup import default_lookup_urls
+import six
+
+try:
+    from __builtin__ import unicode #py2
+except ImportError:
+   from __builtin__ import str as unicode #py3
+
 
 
 class DataModelMetaClass(type):
@@ -51,9 +59,8 @@ class DataModelMetaClass(type):
         setattr(model_cls, 'objects', _meta['engine_class'](model_cls))
         return model_cls
 
-
-class ResourceModel(object, metaclass=DataModelMetaClass):
-
+@six.add_metaclass(DataModelMetaClass)
+class ResourceModel(object):
     def __init__(self, *args, **kwargs):
         """Construct a new model instance
         """
@@ -187,7 +194,7 @@ class ResourceModel(object, metaclass=DataModelMetaClass):
 
     # etc
     def __unicode__(self):
-        return str(self.resource_id)
+        return unicode(self.resource_id)
 
     def __repr__(self):
         return "<%s: %s>" % (self.__class__.__name__, self.__unicode__())

--- a/nap/resources.py
+++ b/nap/resources.py
@@ -3,12 +3,8 @@ from .conf import NapConfig
 from .exceptions import EmptyResponseError
 from .fields import Field
 from .lookup import default_lookup_urls
+from .utils import to_unicode
 import six
-
-
-text_fn = str if six.PY3 else unicode
-def to_unicode(s):
-    return s if isinstance(s, six.text_type) else text_fn(s, 'utf-8')
 
 
 class DataModelMetaClass(type):

--- a/nap/resources.py
+++ b/nap/resources.py
@@ -36,7 +36,7 @@ class DataModelMetaClass(type):
             urls=urls,
         )
 
-        for name, attr in attrs.iteritems():
+        for name, attr in attrs.items():
             if isinstance(attr, Field):
                 attr._name = name
                 fields[name] = attr
@@ -52,9 +52,7 @@ class DataModelMetaClass(type):
         return model_cls
 
 
-class ResourceModel(object):
-
-    __metaclass__ = DataModelMetaClass
+class ResourceModel(object, metaclass=DataModelMetaClass):
 
     def __init__(self, *args, **kwargs):
         """Construct a new model instance
@@ -83,11 +81,11 @@ class ResourceModel(object):
         model_fields = self._meta['fields']
         api_name_map = dict([
             (field.api_name or name, name)
-            for (name, field) in model_fields.iteritems()
+            for (name, field) in model_fields.items()
         ])
 
         extra_data = set(field_data.keys()) - set(api_name_map.keys())
-        for api_name, field_name in api_name_map.iteritems():
+        for api_name, field_name in api_name_map.items():
             model_field = model_fields[field_name]
 
             if api_name in field_data:
@@ -143,7 +141,7 @@ class ResourceModel(object):
         """
         obj_dict = dict([
             (field_name, field.descrub_value(getattr(self, field_name), for_read))
-            for field_name, field in self._meta['fields'].iteritems()
+            for field_name, field in self._meta['fields'].items()
             if for_read or field.readonly is False
         ])
 
@@ -189,7 +187,7 @@ class ResourceModel(object):
 
     # etc
     def __unicode__(self):
-        return unicode(self.resource_id)
+        return str(self.resource_id)
 
     def __repr__(self):
         return "<%s: %s>" % (self.__class__.__name__, self.__unicode__())

--- a/nap/resources.py
+++ b/nap/resources.py
@@ -190,7 +190,8 @@ class ResourceModel(object):
 
     # etc
     def __unicode__(self):
-        return to_unicode(self.resource_id)
+        val = to_unicode(self.resource_id)
+        return val or ''
 
     def __repr__(self):
         return "<%s: %s>" % (self.__class__.__name__, self.__unicode__())

--- a/nap/resources.py
+++ b/nap/resources.py
@@ -5,11 +5,10 @@ from .fields import Field
 from .lookup import default_lookup_urls
 import six
 
-try:
-    from __builtin__ import unicode #py2
-except ImportError:
-   from __builtin__ import str as unicode #py3
 
+text_fn = str if six.PY3 else unicode
+def to_unicode(s):
+    return s if isinstance(s, six.text_type) else text_fn(s, 'utf-8')
 
 
 class DataModelMetaClass(type):
@@ -194,7 +193,7 @@ class ResourceModel(object):
 
     # etc
     def __unicode__(self):
-        return unicode(self.resource_id)
+        return to_unicode(self.resource_id)
 
     def __repr__(self):
         return "<%s: %s>" % (self.__class__.__name__, self.__unicode__())

--- a/nap/serializers.py
+++ b/nap/serializers.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import json
 
 

--- a/nap/utils.py
+++ b/nap/utils.py
@@ -22,10 +22,7 @@ def handle_slash(url, add_slash=None):
 
 
 def is_string_like(obj):
-    try:
-        return isinstance(obj, six.string_types)
-    except NameError:
-        return isinstance(obj, six.string_types)
+    return isinstance(obj, six.string_types)
 
 
 def make_url(base_url, params=None, add_slash=None):

--- a/nap/utils.py
+++ b/nap/utils.py
@@ -51,3 +51,10 @@ def make_url(base_url, params=None, add_slash=None):
         base_url = "%s?%s" % (base_url, param_string)
 
     return base_url
+
+
+__text_fn = str if six.PY3 else unicode
+def to_unicode(s): 
+    if s is None:
+       return None
+    return s if isinstance(s, six.text_type) else __text_fn(s, 'utf-8')

--- a/nap/utils.py
+++ b/nap/utils.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import itertools
-import urllib.request, urllib.parse, urllib.error
+import six
+from six.moves import urllib
 
 
 def handle_slash(url, add_slash=None):
@@ -21,9 +23,9 @@ def handle_slash(url, add_slash=None):
 
 def is_string_like(obj):
     try:
-        return isinstance(obj, str)
+        return isinstance(obj, six.string_types)
     except NameError:
-        return isinstance(obj, str)
+        return isinstance(obj, six.string_types)
 
 
 def make_url(base_url, params=None, add_slash=None):

--- a/nap/utils.py
+++ b/nap/utils.py
@@ -1,5 +1,5 @@
 import itertools
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 
 def handle_slash(url, add_slash=None):
@@ -21,7 +21,7 @@ def handle_slash(url, add_slash=None):
 
 def is_string_like(obj):
     try:
-        return isinstance(obj, basestring)
+        return isinstance(obj, str)
     except NameError:
         return isinstance(obj, str)
 
@@ -42,13 +42,13 @@ def make_url(base_url, params=None, add_slash=None):
 
         flat_params = [
             flatten_params(k, v)
-            for (k, v) in params.iteritems()
+            for (k, v) in params.items()
         ]
 
         # since we can have more than one value for a single key, we use a
         # tuple of two tuples instead of a dictionary
         params_tuple = tuple(itertools.chain(*flat_params))
-        param_string = urllib.urlencode(params_tuple)
+        param_string = urllib.parse.urlencode(params_tuple)
         base_url = "%s?%s" % (base_url, param_string)
 
     return base_url

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     zip_safe=False,
     tests_require=test_requirements,
     install_requires=[
-        'requests==1.2.3',
+        'requests>=1.2.3',
     ] + test_requirements,
     classifiers=[
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import unicode_literals
 from datetime import datetime
 from setuptools import setup, find_packages
 
@@ -18,7 +19,7 @@ setup(
     zip_safe=False,
     tests_require=test_requirements,
     install_requires=[
-        'requests>=1.2.3',
+        'requests>=1.2.3', 'six'
     ] + test_requirements,
     classifiers=[
         'Environment :: Web Environment',

--- a/tests/django_settings.py
+++ b/tests/django_settings.py
@@ -11,6 +11,7 @@
 # situations, so it is recommended to run the test suite against as many
 # database backends as possible.  You may want to create a separate settings
 # file for each of the backends you test against.
+from __future__ import unicode_literals
 
 DATABASES = {
     'default': {

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from nap import auth
 from .utils import get_nap_request
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from __future__ import absolute_import
 from nap import auth
 from .utils import get_nap_request
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import mock
 import pytest
 from . import SampleResourceModel

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from __future__ import absolute_import
 import mock
 import pytest
 from . import SampleResourceModel

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -23,7 +23,7 @@ class TestBaseCacheBackend(object):
 
         defaults.update(kwargs)
         mock_request = mock.Mock()
-        for attr, val in defaults.iteritems():
+        for attr, val in defaults.items():
             setattr(mock_request, attr, val)
 
         return mock_request
@@ -37,7 +37,7 @@ class TestBaseCacheBackend(object):
 
         defaults.update(kwargs)
         mock_response = mock.Mock()
-        for attr, val in defaults.iteritems():
+        for attr, val in defaults.items():
             setattr(mock_response, attr, val)
 
         return mock_response

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from nap.collection import ListWithAttributes
 
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from nap.conf import NapConfig, DEFAULT_CONFIG
 from nap.auth import BaseAuthorization
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -5,7 +5,7 @@ from nap.auth import BaseAuthorization
 def test_config_defaults():
     config = NapConfig()
 
-    for key, value in DEFAULT_CONFIG.iteritems():
+    for key, value in DEFAULT_CONFIG.items():
         assert config[key] == value
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from __future__ import absolute_import
 import json
 import unittest
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import json
 import unittest
 
@@ -130,10 +131,10 @@ class TestResourceEngineAccessMethods(BaseResourceModelTest):
         engine = self.get_engine()
         with mock.patch('nap.engine.ResourceEngine.get_from_uri') as g:
             engine.get('/some/uri/')
-            g.assert_called_once
+            assert g.called
         with mock.patch('nap.engine.ResourceEngine.lookup') as lookup:
             engine.get(pk=1)
-            lookup.assert_called_once
+            assert lookup.called
 
     def test_lookup(self):
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -336,7 +336,7 @@ class TestResourceEngineWriteMethods(BaseResourceModelTest, unittest.TestCase):
             content='Blank Content')
 
         url = dm.get_update_url()
-        assert url == u'expected_title/'
+        assert url == 'expected_title/'
         SampleResourceModel._lookup_urls = []
 
     def test_update(self):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import mock
 
 from nap.exceptions import InvalidStatusError, BadRequestError

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -112,7 +112,7 @@ class TestFields(object):
         }
         resource_dict = field.scrub_value(author_dict_dict)
 
-        assert len(resource_dict.keys()) == 2
+        assert len(list(resource_dict.keys())) == 2
         assert resource_dict['main'].name == 'Jacob'
         assert resource_dict['main'].email == 'elitist@gmail.com'
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from __future__ import absolute_import
 import datetime
 import pytest
 from decimal import Decimal
@@ -113,7 +114,7 @@ class TestFields(object):
         }
         resource_dict = field.scrub_value(author_dict_dict)
 
-        assert len(list(resource_dict.keys())) == 2
+        assert len(resource_dict.keys()) == 2
         assert resource_dict['main'].name == 'Jacob'
         assert resource_dict['main'].email == 'elitist@gmail.com'
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import datetime
 import pytest
 from decimal import Decimal

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import pytest
 
 from nap.http import NapRequest, NapResponse

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from nap.lookup import LookupURL
 
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import json
 
 import mock

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from __future__ import absolute_import
 import json
 
 import mock

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import nap
 from nap.exceptions import EmptyResponseError
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from __future__ import absolute_import
 import nap
 from nap.exceptions import EmptyResponseError
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import json
 
 import pytest

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from nap.utils import make_url, is_string_like, handle_slash
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,7 +31,7 @@ def test_add_slash():
 def test_stringlike():
 
     assert is_string_like('hello') is True
-    assert is_string_like(u'hello') is True
+    assert is_string_like('hello') is True
     assert is_string_like(123) is False
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from nap.http import NapRequest
 
 


### PR DESCRIPTION
Hi guys, 

Here's a stab at making nap work with python2 or python3. In general the changes were:

1. Removing 'u' prefix from lots of places and adding 'from __future__ import unicode_literals'
2. Handling response.content which is now a byte string for py3
3. Dict.iteritems becomes .items which is an interator in py3 and a list in py2, but I don't think that's actually going to be an issue. 
4. Updating setup.py to allow newer versions of requests 

I seem to recall the process with this repo is to merge into master, make a release label, then use that label in dependent projects. If this seems like a reasonable thing to get into 6.10, I'd like to do that this week if possible. 