### PR TITLE
Handle non-string types in nap.utils.to_unicode

### DIFF
--- a/nap/utils.py
+++ b/nap/utils.py
@@ -54,7 +54,20 @@ def make_url(base_url, params=None, add_slash=None):
 
 
 __text_fn = str if six.PY3 else unicode
-def to_unicode(s): 
+
+
+def to_unicode(s):
     if s is None:
-       return None
-    return s if isinstance(s, six.text_type) else __text_fn(s, 'utf-8')
+        return None
+
+    # unicode strings
+    elif isinstance(s, six.text_type):
+        return s
+
+    # non-unicode strings
+    elif isinstance(s, six.binary_type):
+        return __text_fn(s, 'utf-8')
+
+    # non-string types
+    else:
+        return __text_fn(s)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from nap.utils import make_url, is_string_like, handle_slash
+from nap.utils import make_url, is_string_like, handle_slash, to_unicode
 
 
 def test_url():
@@ -50,3 +51,20 @@ class TestHandleTest(object):
         uri = "something.com/?q=bob&x=sue"
         new_uri = handle_slash(uri, add_slash=False)
         assert new_uri == "something.com?q=bob&x=sue"
+
+
+def test_to_unicode_handles_none():
+    assert to_unicode(None) is None
+
+
+def test_to_unicode_handles_unicode():
+    assert isinstance(to_unicode(u'太郎 田中'), unicode)
+
+
+def test_to_unicode_handles_binary():
+    assert isinstance(to_unicode('The arsonist has oddly shaped feet'), unicode)
+
+
+def test_to_unicode_handles_non_string_type():
+    assert isinstance(to_unicode(525600), unicode)
+


### PR DESCRIPTION
update `nap.utils.to_unicode` to handle non-string types just like `ctar_lib.cstar.py23.to_unicode` does for 7_00.