### PR TITLE
ILL-1487 add url normalization to prevent invalid caching

### DIFF
--- a/nap/cache/base.py
+++ b/nap/cache/base.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import re
 
+
 DEFAULT_TIMEOUT = 60 * 5
 
 

--- a/nap/cache/base.py
+++ b/nap/cache/base.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 import re
 
-
 DEFAULT_TIMEOUT = 60 * 5
 
 

--- a/nap/engine.py
+++ b/nap/engine.py
@@ -7,7 +7,7 @@ from .collection import ListWithAttributes
 from .exceptions import InvalidStatusError, BadRequestError
 from .http import NapRequest, NapResponse
 from .serializers import JSONSerializer
-from .utils import handle_slash, make_url, to_unicode
+from .utils import handle_slash, make_url, normalize_url, to_unicode
 
 
 class ResourceEngine(object):
@@ -92,7 +92,7 @@ class ResourceEngine(object):
                     add_slash=self.model._meta['add_slash']
                 )
 
-                return full_url
+                return normalize_url(full_url)
 
         raise ValueError("No valid url")
 

--- a/nap/utils.py
+++ b/nap/utils.py
@@ -1,7 +1,22 @@
 from __future__ import unicode_literals
 import itertools
+from urllib import urlencode
+from urlparse import parse_qsl, urlsplit, urlunsplit
+
 import six
 from six.moves import urllib
+
+
+def normalize_url(url_string):
+    url = urlsplit(url_string)
+    if url.query:
+        query_params = sorted(parse_qsl(url.query, keep_blank_values=True), key=lambda key_value: key_value[0])
+        query_normalized = urlencode(query_params)
+        url = url._replace(query=query_normalized)
+
+    # urlsplit'ing and urlunsplit'ing does some normalization, so apply them even if there is not a query string.
+    # See https://docs.python.org/2/library/urlparse.html#urlparse.urlunsplit for more details.
+    return urlunsplit(url)
 
 
 def handle_slash(url, add_slash=None):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -57,6 +57,19 @@ class TestBaseCacheBackend(object):
         key = cache_backend.get_cache_key(SampleResourceModel, url)
         assert key == "note::http://foo.com/v1/expected_title/"
 
+    def test_get_cache_key_with_parameters(self):
+        kwargs = {'c': 1, 'b': 2, 'a_list': [5, 4, 3]}
+        obj = SampleResourceModel(
+            title='expected_title',
+            content='Blank Content',
+        )
+        cache_backend = self.get_backend()
+
+        uri = SampleResourceModel.objects.get_lookup_url(resource_obj=obj, **kwargs)
+        url = SampleResourceModel.objects.get_full_url(uri)
+        key = cache_backend.get_cache_key(SampleResourceModel, url)
+        assert key == "note::http://foo.com/v1/expected_title/?a_list=5&a_list=4&a_list=3&b=2&c=1"
+
     def test_get_timeout_from_header(self):
         cache_backend = self.get_backend()
         headers = {

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -52,14 +52,21 @@ class TestResourceModelURLMethods(BaseResourceModelTest):
         assert final_uri_with_params == '1/2/?extra_param=3'
         SampleResourceModel._lookup_urls = []
 
-    def test_get_lookup_url_with_list_params(self):
+    @pytest.mark.parametrize('test_kwargs', [
+        {'a_list': [5, 4, 3], 'b': 2, 'c': 1},
+        {'a_list': [5, 4, 3], 'c': 1, 'b': 2},
+        {'b': 2, 'a_list': [5, 4, 3], 'c': 1},
+        {'b': 2, 'c': 1, 'a_list': [5, 4, 3]},
+        {'c': 1, 'a_list': [5, 4, 3], 'b': 2},
+        {'c': 1, 'b': 2, 'a_list': [5, 4, 3]},
+    ])
+    def test_get_lookup_url_with_list_params(self, test_kwargs):
         engine = self.get_engine()
-        kwargs = {'c': 1, 'b': 2, 'a_list': [5, 4, 3]}
 
         final_uri_with_params = engine.get_lookup_url(
             hello='hai',
             what='wut',
-            **kwargs
+            **test_kwargs
         )
         assert final_uri_with_params == 'hai/wut/?a_list=5&a_list=4&a_list=3&b=2&c=1'
         SampleResourceModel._lookup_urls = []

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -52,6 +52,18 @@ class TestResourceModelURLMethods(BaseResourceModelTest):
         assert final_uri_with_params == '1/2/?extra_param=3'
         SampleResourceModel._lookup_urls = []
 
+    def test_get_lookup_url_with_list_params(self):
+        engine = self.get_engine()
+        kwargs = {'c': 1, 'b': 2, 'a_list': [5, 4, 3]}
+
+        final_uri_with_params = engine.get_lookup_url(
+            hello='hai',
+            what='wut',
+            **kwargs
+        )
+        assert final_uri_with_params == 'hai/wut/?a_list=5&a_list=4&a_list=3&b=2&c=1'
+        SampleResourceModel._lookup_urls = []
+
     def test_delete_url(self):
 
         engine = self.get_engine()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 import json
 import unittest
+from collections import OrderedDict
 
 import pytest
 import mock
@@ -53,12 +54,12 @@ class TestResourceModelURLMethods(BaseResourceModelTest):
         SampleResourceModel._lookup_urls = []
 
     @pytest.mark.parametrize('test_kwargs', [
-        {'a_list': [5, 4, 3], 'b': 2, 'c': 1},
-        {'a_list': [5, 4, 3], 'c': 1, 'b': 2},
-        {'b': 2, 'a_list': [5, 4, 3], 'c': 1},
-        {'b': 2, 'c': 1, 'a_list': [5, 4, 3]},
-        {'c': 1, 'a_list': [5, 4, 3], 'b': 2},
-        {'c': 1, 'b': 2, 'a_list': [5, 4, 3]},
+        OrderedDict([('a_list', [5, 4, 3]), ('b', 2), ('c', 1)]),
+        OrderedDict([('a_list', [5, 4, 3]), ('c', 1), ('b', 2)]),
+        OrderedDict([('b', 2), ('a_list', [5, 4, 3]), ('c', 1)]),
+        OrderedDict([('b', 2), ('c', 1), ('a_list', [5, 4, 3])]),
+        OrderedDict([('c', 1), ('a_list', [5, 4, 3]), ('b', 2)]),
+        OrderedDict([('c', 1), ('b', 2), ('a_list', [5, 4, 3])]),
     ])
     def test_get_lookup_url_with_list_params(self, test_kwargs):
         engine = self.get_engine()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,26 @@
 from __future__ import unicode_literals
-from nap.utils import make_url, is_string_like, handle_slash
+
+from nap.utils import make_url, is_string_like, handle_slash, normalize_url
+
+
+class TestNormalizeUrl(object):
+    def test_normalize_url(self):
+        url = "https://example.com/path/?two=3&one=1&two=2"
+        expected_normalized_url = "https://example.com/path/?one=1&two=3&two=2"
+
+        actual_normalized_url = normalize_url(url)
+        assert actual_normalized_url == expected_normalized_url
+
+    def test_normalize_partial_url(self):
+        url = (
+            "https://foo.bar.example.com"
+        )
+        expected_normalized_url = (
+            "https://foo.bar.example.com"
+        )
+
+        actual_normalized_url = normalize_url(url)
+        assert actual_normalized_url == expected_normalized_url
 
 
 def test_url():


### PR DESCRIPTION
This commit adds a utility function, normalize_url, that is
used in _generate_url to sort query parameters in a url
while maintaining the order of lists and duplicate keys.

The purpose of this change is to prevent the situation
where extra parameters are used in a resource lookup,
but may be passed in different ways, causing the same entity
to be cached using more than one url leading
to invalid cache states and cache misses.

This is based off of the work done in the [ILL-1432 PR](https://github.com/CashStar/nap/pull/12), but has been squashed to make the history cleaner for merging. Also, more tests were added, the location of the normalization logic was moved, and parameters are only sorted on keys not values to preserve lists.