### PR TITLE
encode unicode strings to UTF-8 so that python can urlencode them

### DIFF
--- a/nap/engine.py
+++ b/nap/engine.py
@@ -7,7 +7,7 @@ from .collection import ListWithAttributes
 from .exceptions import InvalidStatusError, BadRequestError
 from .http import NapRequest, NapResponse
 from .serializers import JSONSerializer
-from .utils import handle_slash, make_url, to_unicode
+from .utils import handle_slash, make_url, normalize_url, to_unicode
 
 
 class ResourceEngine(object):
@@ -92,7 +92,7 @@ class ResourceEngine(object):
                     add_slash=self.model._meta['add_slash']
                 )
 
-                return full_url
+                return normalize_url(full_url)
 
         raise ValueError("No valid url")
 

--- a/nap/engine.py
+++ b/nap/engine.py
@@ -7,7 +7,7 @@ from .collection import ListWithAttributes
 from .exceptions import InvalidStatusError, BadRequestError
 from .http import NapRequest, NapResponse
 from .serializers import JSONSerializer
-from .utils import handle_slash, make_url, normalize_url, to_unicode
+from .utils import handle_slash, make_url, to_unicode
 
 
 class ResourceEngine(object):
@@ -92,7 +92,7 @@ class ResourceEngine(object):
                     add_slash=self.model._meta['add_slash']
                 )
 
-                return normalize_url(full_url)
+                return full_url
 
         raise ValueError("No valid url")
 

--- a/nap/utils.py
+++ b/nap/utils.py
@@ -24,6 +24,10 @@ def handle_slash(url, add_slash=None):
 def is_string_like(obj):
     return isinstance(obj, six.string_types)
 
+def safe_encode(value):
+    if isinstance(value, six.text_type):
+        return value.encode('utf-8')
+    return value
 
 def make_url(base_url, params=None, add_slash=None):
     "Split off in case we need to handle more scrubing"
@@ -31,12 +35,6 @@ def make_url(base_url, params=None, add_slash=None):
     base_url = handle_slash(base_url, add_slash)
 
     if params:
-
-        def safe_encode(value):
-            if isinstance(value, six.text_type):
-                return value.encode('utf-8')
-            return value
-
         # If we're given an non-string iterable as a params value,
         # we want to pass in multiple instances of that param key.
         def flatten_params(k, vs):

--- a/nap/utils.py
+++ b/nap/utils.py
@@ -32,13 +32,13 @@ def make_url(base_url, params=None, add_slash=None):
 
     if params:
 
-        # If we're given an non-string iterable as a params value,
-        # we want to pass in multiple instances of that param key.
         def safe_encode(value):
             if isinstance(value, six.text_type):
                 return value.encode('utf-8')
             return value
 
+        # If we're given an non-string iterable as a params value,
+        # we want to pass in multiple instances of that param key.
         def flatten_params(k, vs):
             if not hasattr(vs, '__iter__') or is_string_like(vs):
                 return ((k, safe_encode(vs)),)

--- a/nap/utils.py
+++ b/nap/utils.py
@@ -1,21 +1,7 @@
 from __future__ import unicode_literals
 import itertools
 from six.moves.urllib.parse import urlencode
-from six.moves.urllib.parse import parse_qsl, urlsplit, urlunsplit
 import six
-from six.moves import urllib
-
-
-def normalize_url(url_string):
-    url = urlsplit(url_string)
-    if url.query:
-        query_params = sorted(parse_qsl(url.query, keep_blank_values=True), key=lambda key_value: key_value[0])
-        query_normalized = urlencode(query_params)
-        url = url._replace(query=query_normalized)
-
-    # urlsplit'ing and urlunsplit'ing does some normalization, so apply them even if there is not a query string.
-    # See https://docs.python.org/2/library/urlparse.html#urlparse.urlunsplit for more details.
-    return urlunsplit(url)
 
 
 def handle_slash(url, add_slash=None):
@@ -46,12 +32,20 @@ def make_url(base_url, params=None, add_slash=None):
 
     if params:
 
+        def safe_encode(value):
+            try:
+                if isinstance(value, unicode):
+                    return value.encode('utf-8')
+                return value
+            except AttributeError:
+                return value
+
         # If we're given an non-string iterable as a params value,
         # we want to pass in multiple instances of that param key.
         def flatten_params(k, vs):
             if not hasattr(vs, '__iter__') or is_string_like(vs):
-                return ((k, vs),)
-            return [(k, v) for v in vs]
+                return ((k, safe_encode(vs)),)
+            return [(k, safe_encode(v)) for v in vs]
 
         flat_params = [
             flatten_params(k, v)
@@ -60,19 +54,21 @@ def make_url(base_url, params=None, add_slash=None):
 
         # since we can have more than one value for a single key, we use a
         # tuple of two tuples instead of a dictionary
-        params_tuple = tuple(itertools.chain(*flat_params))
-        param_string = urllib.parse.urlencode(params_tuple)
+        params_tuple = tuple(sorted(itertools.chain(*flat_params)))
+        param_string = urlencode(params_tuple)
         base_url = "%s?%s" % (base_url, param_string)
 
     return base_url
 
 
 __text_fn = str if six.PY3 else unicode
-def to_unicode(s): 
+
+
+def to_unicode(s):
     if s is None:
         return None
 
-    # unicode strings    
+    # unicode strings
     elif isinstance(s, six.text_type):
         return s
 

--- a/nap/utils.py
+++ b/nap/utils.py
@@ -1,7 +1,19 @@
 from __future__ import unicode_literals
 import itertools
-from six.moves.urllib.parse import urlencode
 import six
+from six.moves.urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+
+def normalize_url(url_string):
+    url = urlsplit(url_string)
+    if url.query:
+        query_params = sorted(parse_qsl(url.query, keep_blank_values=True), key=lambda key_value: key_value[0])
+        query_normalized = urlencode(query_params)
+        url = url._replace(query=query_normalized)
+
+    # urlsplit'ing and urlunsplit'ing does some normalization, so apply them even if there is not a query string.
+    # See https://docs.python.org/2/library/urlparse.html#urlparse.urlunsplit for more details.
+    return urlunsplit(url)
 
 
 def handle_slash(url, add_slash=None):
@@ -33,12 +45,9 @@ def make_url(base_url, params=None, add_slash=None):
     if params:
 
         def safe_encode(value):
-            try:
-                if isinstance(value, unicode):
-                    return value.encode('utf-8')
-                return value
-            except AttributeError:
-                return value
+            if isinstance(value, six.text_type):
+                return value.encode('utf-8')
+            return value
 
         # If we're given an non-string iterable as a params value,
         # we want to pass in multiple instances of that param key.
@@ -54,7 +63,7 @@ def make_url(base_url, params=None, add_slash=None):
 
         # since we can have more than one value for a single key, we use a
         # tuple of two tuples instead of a dictionary
-        params_tuple = tuple(sorted(itertools.chain(*flat_params)))
+        params_tuple = tuple(itertools.chain(*flat_params))
         param_string = urlencode(params_tuple)
         base_url = "%s?%s" % (base_url, param_string)
 

--- a/nap/utils.py
+++ b/nap/utils.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 import itertools
+from operator import itemgetter
 import six
 from six.moves.urllib.parse import urlencode
 
@@ -24,10 +25,12 @@ def handle_slash(url, add_slash=None):
 def is_string_like(obj):
     return isinstance(obj, six.string_types)
 
+
 def safe_encode(value):
     if isinstance(value, six.text_type):
         return value.encode('utf-8')
     return value
+
 
 def make_url(base_url, params=None, add_slash=None):
     "Split off in case we need to handle more scrubing"
@@ -49,7 +52,7 @@ def make_url(base_url, params=None, add_slash=None):
 
         # since we can have more than one value for a single key, we use a
         # tuple of two tuples instead of a dictionary
-        params_tuple = tuple(sorted(itertools.chain(*flat_params), key=lambda key_value: key_value[0]))
+        params_tuple = tuple(sorted(itertools.chain(*flat_params), key=itemgetter(0)))
         param_string = urlencode(params_tuple)
         base_url = "%s?%s" % (base_url, param_string)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,6 +37,11 @@ def test_stringlike():
     assert is_string_like(123) is False
 
 
+def test_unicode():
+    url = make_url("http://www.naprulez.org/", params={'x': u'\u0414'})
+    assert url == "http://www.naprulez.org/?x=%D0%94"
+
+
 class TestHandleTest(object):
 
     def test_has_get_params(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,26 +1,6 @@
 from __future__ import unicode_literals
 
-from nap.utils import make_url, is_string_like, handle_slash, normalize_url
-
-
-class TestNormalizeUrl(object):
-    def test_normalize_url(self):
-        url = "https://example.com/path/?two=3&one=1&two=2"
-        expected_normalized_url = "https://example.com/path/?one=1&two=3&two=2"
-
-        actual_normalized_url = normalize_url(url)
-        assert actual_normalized_url == expected_normalized_url
-
-    def test_normalize_partial_url(self):
-        url = (
-            "https://foo.bar.example.com"
-        )
-        expected_normalized_url = (
-            "https://foo.bar.example.com"
-        )
-
-        actual_normalized_url = normalize_url(url)
-        assert actual_normalized_url == expected_normalized_url
+from nap.utils import make_url, is_string_like, handle_slash
 
 
 def test_url():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,21 @@ from __future__ import unicode_literals
 
 from nap.utils import make_url, is_string_like, handle_slash
 
+def test_url_is_normalized():
+    base_url = "https://example.com/path/"
+    params = {'two': [3, 2], 'one': 1}
+    expected_normalized_url = "https://example.com/path/?one=1&two=3&two=2"
+
+    actual_normalized_url = make_url(base_url, params)
+    assert actual_normalized_url == expected_normalized_url
+
+def test_partial_url_is_normalized():
+    base_url = "https://foo.bar.example.com"
+    params = {}
+    expected_normalized_url = "https://foo.bar.example.com"
+
+    actual_normalized_url = make_url(base_url, params)
+    assert actual_normalized_url == expected_normalized_url
 
 def test_url():
     url = make_url("http://www.naprulez.org/", params={'x': '1'})


### PR DESCRIPTION
urlencode doesn't like unicode strings. Need first to encode these strings to UTF-8 to allow unicode to pass through nap.

I also noticed that normalize url could be turned into a one-liner by adding sorted to the expression that's assigned to  params_tuple in make_url