### PR TITLE
ARCH-1867 - fix handling of unicode characters in resource repr

### DIFF
--- a/nap/lookup.py
+++ b/nap/lookup.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 import re
 from .utils import to_unicode
+import six
 
 
 class LookupURL(object):
@@ -56,7 +57,9 @@ class LookupURL(object):
         return to_unicode(self.url_string)
 
     def __repr__(self):
-        return "<%s: %s>" % (self.__class__.__name__, self.__unicode__())
+        val = "<%s: %s>" % (self.__class__.__name__, self.__unicode__())
+        # For py2 repr needs to return a non-unicode string and in py3 it's the opposite
+        return val.encode('utf8') if six.PY2 else val
 
 
 def nap_url(*args, **kwargs):

--- a/nap/resources.py
+++ b/nap/resources.py
@@ -194,4 +194,7 @@ class ResourceModel(object):
         return val or ''
 
     def __repr__(self):
-        return "<%s: %s>" % (self.__class__.__name__, self.__unicode__())
+        val = "<%s: %s>" % (self.__class__.__name__, self.__unicode__())
+        # For py2 repr needs to return a non-unicode string and in py3 it's the opposite
+        return val.encode('utf8') if six.PY2 else val
+


### PR DESCRIPTION
Return non-unicode string from \_\_repr__ methods for py2 and unicode string for py3. 