### PR TITLE
Update DecimalField to distinguish between empty and 0 values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 htmlcov
 _build
 __pycache__
+.cache
 scratch.py
 secret.py
 build

--- a/nap/fields.py
+++ b/nap/fields.py
@@ -116,7 +116,8 @@ class DecimalField(Field):
         """Return a Decimal object using the provided value.
 
         If the provided value is None or empty return None instead
-        of returning a Decimal.
+        of returning a Decimal.  Otherwise convert the provided value
+        to a string before constructing the Decimal.
         """
         if val is None:
             return None

--- a/nap/fields.py
+++ b/nap/fields.py
@@ -113,10 +113,30 @@ class DateField(Field):
 
 class DecimalField(Field):
     def scrub_value(self, val):
-        return Decimal(str(val)) if val else None
+        """Return a Decimal object using the provided value.
+
+        If the provided value is None or empty return None instead
+        of returning a Decimal.
+        """
+        if val is None:
+            return None
+
+        val = str(val)
+
+        return Decimal(val) if val else None
 
     def descrub_value(self, val, for_read=False):
-        return str(val) if val else None
+        """Return a string representation of the provided value
+
+        If the provided value is None or empty return None instead
+        of returning a string.
+        """
+        if val is None:
+            return None
+
+        val = str(val)
+
+        return val or None
 
 
 class ResourceField(Field):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -215,7 +215,7 @@ class TestFields(object):
         # existing list returns the same list
         assert [1,2,3,4] == field.scrub_value([1,2,3,4])
 
-        # existing tuple 
+        # existing tuple
         assert [123] == field.scrub_value(123,)
 
         # None results in an empty list for ease of use
@@ -226,11 +226,11 @@ class TestFields(object):
         assert ['0'] == field.scrub_value('0')
         assert [''], field.scrub_value('')
 
-        # ---- descrub 
+        # ---- descrub
         # existing list returns the same list
         assert [1,2,3,4] == field.descrub_value([1,2,3,4])
 
-        # existing tuple 
+        # existing tuple
         assert [123] == field.descrub_value(123,)
 
         # None results in an empty list for ease of use
@@ -241,14 +241,34 @@ class TestFields(object):
         assert ['0'] == field.descrub_value('0')
         assert [''], field.descrub_value('')
 
-
     def test_decimal_field(self):
+        # Given a decimal field
         field = DecimalField()
 
+        # When de-serialized values are provided
+        # Then it converts them to Decimals
         assert Decimal('10.0') == field.scrub_value(Decimal('10.0'))
         assert Decimal('10.0') == field.scrub_value('10.0')
-        assert None == field.scrub_value(None)
+        assert Decimal('10.0') == field.scrub_value(float('10.0'))
+        assert Decimal('0') == field.scrub_value(Decimal('0.0'))
+        assert Decimal('0') == field.scrub_value('0.0')
+        assert Decimal('0') == field.scrub_value(float('0.0'))
 
+        # When empty de-serialized values are provided
+        # Then it converts them to None
+        assert field.scrub_value(None) is None
+        assert field.scrub_value('') is None
+
+        # When serialized values are provided
+        # Then it converts them to strings
         assert '10.0' == field.descrub_value(Decimal('10.0'))
         assert '10.0' == field.descrub_value('10.0')
-        assert None == field.descrub_value(None)
+        assert '10.0' == field.descrub_value(float('10.0'))
+        assert '0.0' == field.descrub_value(Decimal('0.0'))
+        assert '0.0' == field.descrub_value('0.0')
+        assert '0.0' == field.descrub_value(float('0.0'))
+
+        # When empty serialized values are provided
+        # Then it converts them to None
+        assert field.descrub_value(None) is None
+        assert field.descrub_value('') is None


### PR DESCRIPTION
This updates nap's DecimalField to distinguish between empty and 0 values when scrubbing and de-scrubbing data.  The issue being fixed is that previously if the integer 0 was provided as the de-serialized value to DecimalField.scrub_value it would treat it as false-like and return None.  I checked out what django-rest-framework serializer fields support and they do distinguish between empty and 0 valued fields, so I took an approach similar to what they and regular django forms take.

For reference, scrub_value could receive the value 0 if the json returned in an http response had 0 instead of '0'. For descrub_value, if a 0 is provided as the initial value for a DecimalField on a new instance of a ResourceModel then it ends up getting set to None.