### PR TITLE
Support md5 hashing part of the cache key above a certain length

### DIFF
--- a/nap/cache/base.py
+++ b/nap/cache/base.py
@@ -1,16 +1,22 @@
 from __future__ import unicode_literals
 import re
+from hashlib import md5
 
 DEFAULT_TIMEOUT = 60 * 5
+# Default value for max cache key length favors memcached limitation of 250 byte key
+# and the assumption the web framework may append additional version to the key.
+MAX_CACHE_KEY_LENGTH = 240
 
 
 class BaseCacheBackend(object):
 
     CACHE_EMPTY = "!!!DNE!!!"
 
-    def __init__(self, default_timeout=DEFAULT_TIMEOUT, obey_cache_headers=True):
+    def __init__(self, default_timeout=DEFAULT_TIMEOUT,
+                 obey_cache_headers=True, cache_max_key_size=MAX_CACHE_KEY_LENGTH):
         self.obey_cache_headers = obey_cache_headers
         self.default_timeout = default_timeout
+        self.cache_max_key_size = cache_max_key_size
 
     def get(self, key):
         return None
@@ -28,16 +34,19 @@ class BaseCacheBackend(object):
             return int(cache_header_age.group(1))
 
     def get_cache_key(self, model, url):
-
+        """ Cache key format is %(resource_name)s::%(url)s where the URL may be
+          md5 hashed when it exceeds length.  strips white space from cache key as
+           its a control character in memcached.
+        """
         resource_name = model._meta['resource_name']
+        cache_key = "{0}::".format(resource_name)
 
-        key_parts = {
-            'resource_name': resource_name,
-            'url': url,
-        }
+        if (len(cache_key) + len(url)) > self.cache_max_key_size:
+            cache_key += md5(url.encode('utf-8')).hexdigest()
+        else:
+            cache_key += url
 
-        cache_key = "%(resource_name)s::%(url)s" % key_parts
-
+        cache_key = cache_key.replace(" ", "")
         return cache_key
 
     def get_timeout(self, response=None):

--- a/nap/cache/base.py
+++ b/nap/cache/base.py
@@ -41,8 +41,10 @@ class BaseCacheBackend(object):
         resource_name = model._meta['resource_name']
         cache_key = "{0}::".format(resource_name)
 
-        if (len(cache_key) + len(url)) > self.cache_max_key_size:
+        if self.cache_max_key_size is not None and (len(cache_key) + len(url)) > self.cache_max_key_size:
             cache_key += md5(url.encode('utf-8')).hexdigest()
+            logger = model._meta['logger']
+            logger.info("Cache key for url {0} exceeds length so hashing to key {1}".format(url, cache_key))
         else:
             cache_key += url
 

--- a/nap/conf.py
+++ b/nap/conf.py
@@ -27,7 +27,7 @@ DEFAULT_CONFIG = {
     'valid_create_status': (201,),
     'valid_delete_status': (200, 202, 204),
     'bad_request_status': (400,),
-    'log_level': 'CRITICAL',
+    'log_level': 'INFO',
     'cache_backend': BaseCacheBackend(),
     'cached_methods': ('GET', ),
     'request_args': {},

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -29,10 +29,10 @@ class TestJSONSerializer(object):
         }
 
         serializer = self.get_serializer()
-
         json_str = serializer.serialize(sample_dict)
+        dict_from_json = json.loads(json_str)
 
-        assert json_str == '{"a": 1, "b": 2}'
+        assert dict_from_json == sample_dict
 
     def test_deserialize(self):
 


### PR DESCRIPTION
This change is largely to ensure that the removing of 'KEY_FUNCTION': make_hashed_key which has always prevented us from seeing what the key values actually are in memcached.  There is a limitation that memcached keys be not longer 250 characters and contain no spaces.   This updates the get_cache_key to default to 240 with an override available on the BaseCacheBackend constructor.

The reason for 240 is to give a 10 character space to the default django KEY_FUNCTION which prepends a version and the KEY_PREFIX if its define. 

Also included is a python 3.5 compatibility change for one of the unit tests.  I discovered this while running the tests for nap.