### PR TITLE
Updated unicode encoding to fix docker pip install issue.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author="Jacob Burch",
     author_email="jacobburch@gmail.com",
     url='https://github.com/jacobb/nap',
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst', encoding='utf').read(),
     packages=find_packages(),
     zip_safe=False,
     setup_requires=['pytest-runner>=2.0,<3dev'],

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 from datetime import datetime
 from setuptools import setup, find_packages
+import io
 
 version = '%s' % datetime.now().strftime("%Y-%m-%d-%H_%M_%S_%f")
 setup(
@@ -11,7 +12,7 @@ setup(
     author="Jacob Burch",
     author_email="jacobburch@gmail.com",
     url='https://github.com/jacobb/nap',
-    long_description=open('README.rst', encoding='utf-8').read(),
+    long_description=io.open('README.rst', encoding='utf-8').read(),
     packages=find_packages(),
     zip_safe=False,
     setup_requires=['pytest-runner>=2.0,<3dev'],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author="Jacob Burch",
     author_email="jacobburch@gmail.com",
     url='https://github.com/jacobb/nap',
-    long_description=open('README.rst', encoding='utf').read(),
+    long_description=open('README.rst', encoding='utf-8').read(),
     packages=find_packages(),
     zip_safe=False,
     setup_requires=['pytest-runner>=2.0,<3dev'],


### PR DESCRIPTION
Docker python3 images were blowing up trying to pip install docker nap due to it using ascii when reading the README.rst file. This change forces setup.py to read it as unicode.