### PR TITLE
ARCH-2849 - log / handle bad cache data

### DIFF
--- a/nap/engine.py
+++ b/nap/engine.py
@@ -471,7 +471,7 @@ class ResourceEngine(object):
             self.logger.debug("Got cached response for %s" % cache_key)
 
             if not isinstance(cached_response, NapResponse):
-                self.logger.error("Expected to get a nap object from cache, but got %s instead: %s",
+                self.logger.error("Expected to get a NapResponse from cache, but got %s instead: %s",
                     type(cached_response), cached_response)
 
                 # We've got some sort of garbage back from memcache. Let's not use it. 

--- a/nap/engine.py
+++ b/nap/engine.py
@@ -470,11 +470,18 @@ class ResourceEngine(object):
         if cached_response:
             self.logger.debug("Got cached response for %s" % cache_key)
 
-            # Cached responses should not get re-cached to allow for
-            # expected timeouts. Now that we've retrieved the cached
-            # response, behave as if cache is turned off.
-            cached_response.use_cache = False
-            return cached_response
+            if not isinstance(cached_response, NapResponse):
+                self.logger.error("Expected to get a nap object from cache, but got %s instead: %s",
+                    type(cached_response), cached_response)
+
+                # We've got some sort of garbage back from memcache. Let's not use it. 
+                return None
+            else:
+                # Cached responses should not get re-cached to allow for
+                # expected timeouts. Now that we've retrieved the cached
+                # response, behave as if cache is turned off.
+                cached_response.use_cache = False
+                return cached_response
 
     def cache_response(self, response):
         if response.request_method not in self.model._meta['cached_methods']\
@@ -534,3 +541,4 @@ class ResourceEngine(object):
 
         full_url = "%s/%s" % (root_url.rstrip('/'), uri.lstrip('/'))
         return full_url
+

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -343,6 +343,24 @@ class TestCacheFunctions(object):
 
         assert not cache_set.called
 
+    @mock.patch('requests.request')
+    @mock.patch('nap.cache.base.BaseCacheBackend.get')
+    def test_invalid_cache_result_found(self, mock_get, mock_request):
+
+        cached_response = 'Invalid cache value - should be a nap response'
+        mock_get.return_value = cached_response
+
+        response = NapResponse(
+            content=json.dumps({'id': 1, 'title': 'hello!'}),
+            url='some-url/',
+            status_code=200,
+            request_method='POST',
+        )
+        mock_request.return_value = response
+
+        res = SampleResourceModel.objects.get_from_uri('some-url/')
+        assert mock_request.called
+
 
 class TestResourceEngineWriteMethods(BaseResourceModelTest, unittest.TestCase):
 


### PR DESCRIPTION
We're seeing a sporadic issue where the object we're getting back from memcache appears to be some type other than NapResponse (it's often a string). Let's add some logging and better error handling. 