### PR TITLE
ARCH-3001 Improve logging in nap

### DIFF
--- a/nap/engine.py
+++ b/nap/engine.py
@@ -21,7 +21,7 @@ class ResourceEngine(object):
 
         full_url = self.get_full_url(url)
 
-        self.logger.info("Trying to hit %s" % full_url)
+        self.logger.info("Calling %s url: %s" % (request_method, full_url))
 
         request_args = self.get_request_args(kwargs)
 


### PR DESCRIPTION
I think this is an improvement to the log level of nap because it adds the HTTP request method to the statement and makes the language "Calling GET url:  %s" over "Trying to hit ..." which is more ambiguous.  Plus this mostly matches the revised language in cstar_clients.  It is still possible to tell apart cstar_clients log messages from nap by looking at the prefix in front ... the nap log messages come from the fine engine whereas the cstar_clients log messages come from a file called client.  