### PR TITLE
Ni 5221 clients performance issue

### DIFF
--- a/nap/engine.py
+++ b/nap/engine.py
@@ -163,7 +163,6 @@ class ResourceEngine(object):
         """
 
         uri = self.get_lookup_url(**lookup_vars)
-
         return self.get_from_uri(uri, skip_cache=skip_cache)
 
     def get_from_uri(self, url, skip_cache=False, *args, **kwargs):
@@ -271,7 +270,7 @@ class ResourceEngine(object):
         resource_list = [self.model(**obj_dict) for obj_dict in obj_list]
 
         if not skip_cache:
-            self.handle_response(response)
+            self.cache_response(response)
 
         return ListWithAttributes(resource_list, extra_data)
 

--- a/nap/engine.py
+++ b/nap/engine.py
@@ -57,7 +57,6 @@ class ResourceEngine(object):
             url for url in self.model._meta['urls']
             if getattr(url, url_type, False)
         ]
-
         for url in valid_urls:
             field_values = dict([
                 (var, getattr(resource_obj, var))

--- a/nap/engine.py
+++ b/nap/engine.py
@@ -57,6 +57,7 @@ class ResourceEngine(object):
             url for url in self.model._meta['urls']
             if getattr(url, url_type, False)
         ]
+
         for url in valid_urls:
             field_values = dict([
                 (var, getattr(resource_obj, var))

--- a/nap/engine.py
+++ b/nap/engine.py
@@ -231,7 +231,7 @@ class ResourceEngine(object):
         Accesses the first URL set as a collections URL with no additional
         parameters passed. Returns a list of current ResourceModel objects
 
-        :param skip_cache: If true don't cache results (defaults to true for backwards compatibilty)
+        :param skip_cache: If true don't cache results (defaults to true for backwards compatibilty) and don't check cache for an existing value for this request
         :param lookup_vars: variables to pass to _generate_url
         """
         url = self.get_collection_url(**lookup_vars)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,5 @@
 import nap
+from nap.cache.base import BaseCacheBackend
 
 
 class SampleResourceModel(nap.ResourceModel):
@@ -53,3 +54,33 @@ class AuthorModel(nap.ResourceModel):
 
     class Meta:
         root_url = "http://foo.com/v1/"
+
+
+class InMemoryCache(BaseCacheBackend):
+    _cache = {}
+
+    def get(self, key):
+        return self._cache.get(key)
+
+    def set(self, key, value, response=None):
+        self._cache[key] = value
+
+    def get_cached_data(self):
+        return self._cache
+
+    def clear(self):
+        self._cache = {}
+
+class SampleCacheableResource(nap.ResourceModel):
+    title = nap.Field()
+    content = nap.Field()
+    slug = nap.Field(resource_id=True)
+    alt_name = nap.Field(api_name='some_field')
+
+    class Meta:
+        root_url = "http://foo.com/v1/"
+        resource_name = 'note'
+        append_urls = (
+            nap.lookup.nap_url(r'something/great/', collection=True, lookup=True),
+        )
+        cache_backend = InMemoryCache()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -4,6 +4,7 @@ import mock
 import pytest
 import json
 from flask import Flask
+import unittest
 
 from . import SampleResourceModel, SampleCacheableResource
 from nap.cache import django_cache, flask_cache
@@ -202,7 +203,7 @@ class TestFlaskCacheBackend(TestBaseCacheBackend):
             assert fl_cache_set.called
 
 
-class TestCaching(object):
+class TestCaching(unittest.TestCase):
     def setUp(self):
         self.the_cache = SampleCacheableResource._meta['cache_backend']
         # NOTE: there is a single instance of the in memory (fake) cache for all instances of our model
@@ -212,7 +213,6 @@ class TestCaching(object):
     def test_get_response_from_filter_is_cached(self, mock_request):
         """Test that filter() responses can be cached.
         NOTE: nap only supports GETs on filter() calls. Weird"""
-        self.setUp()
 
         # create mock request nap is going to issue and a mock response that nap will get back
         r = mock.Mock()
@@ -241,7 +241,6 @@ class TestCaching(object):
     @mock.patch('requests.request')
     def test_get_response_from_lookup_is_cached(self, mock_request):
         """Test that lookup() responses can be cached."""
-        self.setUp()
 
         # create mock request nap is going to issue and a mock response that nap will get back
         r = mock.Mock()


### PR DESCRIPTION
This PR adds caching to .filter() calls (for GETs) on nap clients. This works the same as caching on lookup() calls except that if default to not caching by default to match the existing behavior. 

Concerns:

1. Caching filter() calls / collection endpoints may be a concern b/c of the amount of data a typical search endpoint returns. [As you have to explicitly enable caching when calling filter() on your nap client the onus is on the developer to not cache huge amounts of data]
2. This only applies to GETs not any other HTTP method. 