### PR TITLE
Feature/ARCH-3394 Migrate nap codebase to Python 3

### DIFF
--- a/examples/github_gist.py
+++ b/examples/github_gist.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import nap
 from nap.auth import FoauthAuthorization
 from nap.lookup import nap_url
@@ -35,7 +34,11 @@ class Gist(nap.ResourceModel):
         prepend_urls = (
             # For accessing /gists/starred and /gists/public, eg.
             # Gist.filter(property='starred')
-            nap_url('%(resource_name)s/%(property)s', collection=True, lookup=False),
+            nap_url(
+                '%(resource_name)s/%(property)s',
+                collection=True,
+                lookup=False
+            ),
         )
         auth = (
             FoauthAuthorization(secret.foauth_email, secret.foauth_password),

--- a/examples/twitter.py
+++ b/examples/twitter.py
@@ -1,6 +1,4 @@
-from __future__ import unicode_literals
 import nap
-
 
 
 class User(nap.ResourceModel):
@@ -12,10 +10,13 @@ class Tweet(nap.ResourceModel):
     text = nap.Field()
 
     class Meta:
-        root_url = "https://api.twitter.com/1/"
-        resource_name = "statuses"
+        root_url = 'https://api.twitter.com/1/'
+        resource_name = 'statuses'
         add_slash = False
         urls = (
-            nap.nap_url("%(resource_name)s/show.json",
-                params=('id',), lookup=True),
+            nap.nap_url(
+                '%(resource_name)s/show.json',
+                params=('id',),
+                lookup=True
+            ),
         )

--- a/nap/__init__.py
+++ b/nap/__init__.py
@@ -1,11 +1,20 @@
-from __future__ import absolute_import
-from .fields import (Field, ResourceField, DictField, ListField, DateTimeField)
-from .lookup import nap_url
-from .resources import ResourceModel
+from nap.fields import (
+    DateTimeField,
+    DictField,
+    Field,
+    ListField,
+    ResourceField
+)
+from nap.lookup import nap_url
+from nap.resources import ResourceModel
 
 
 __all__ = (
     ResourceModel,
-    DateTimeField, Field, ResourceField, DictField, ListField,
+    DateTimeField,
+    Field,
+    ResourceField,
+    DictField,
+    ListField,
     nap_url
 )

--- a/nap/auth.py
+++ b/nap/auth.py
@@ -1,7 +1,6 @@
-from __future__ import unicode_literals
-from __future__ import absolute_import
 import re
-from .middleware import BaseMiddleware
+
+from nap.middleware import BaseMiddleware
 
 
 class BaseAuthorization(BaseMiddleware):
@@ -9,7 +8,6 @@ class BaseAuthorization(BaseMiddleware):
 
 
 class HttpAuthorization(BaseAuthorization):
-
     def __init__(self, username, password):
         self.username = username
         self.password = password
@@ -25,11 +23,13 @@ class FoauthAuthorization(BaseAuthorization):
     def __init__(self, email, password):
         self.email = email
         self.password = password
+        self.orig_url = None
 
     def handle_request(self, request):
         self.orig_url = request.url
-        pattern = r'https?://'
-        new_url = "https://foauth.org/%s" % re.sub(pattern, '', request.url)
+        new_url = 'https://foauth.org/{}'.format(
+            re.sub(r'https?://', '', request.url)
+        )
         request.auth = (self.email, self.password)
         if request.method == 'PATCH':
             request.headers['X-HTTP-Method-Override'] = 'PATCH'

--- a/nap/cache/base.py
+++ b/nap/cache/base.py
@@ -1,19 +1,22 @@
-from __future__ import unicode_literals
 import re
 from hashlib import md5
 
 DEFAULT_TIMEOUT = 60 * 5
-# Default value for max cache key length favors memcached limitation of 250 byte key
-# and the assumption the web framework may append additional version to the key.
+# Default value for max cache key length favors memcached limitation of 250
+# byte key and the assumption the web framework may append additional version
+# to the key.
 MAX_CACHE_KEY_LENGTH = 240
 
 
-class BaseCacheBackend(object):
+class BaseCacheBackend:
+    CACHE_EMPTY = '!!!DNE!!!'
 
-    CACHE_EMPTY = "!!!DNE!!!"
-
-    def __init__(self, default_timeout=DEFAULT_TIMEOUT,
-                 obey_cache_headers=True, cache_max_key_size=MAX_CACHE_KEY_LENGTH):
+    def __init__(
+            self,
+            default_timeout=DEFAULT_TIMEOUT,
+            obey_cache_headers=True,
+            cache_max_key_size=MAX_CACHE_KEY_LENGTH
+    ):
         self.obey_cache_headers = obey_cache_headers
         self.default_timeout = default_timeout
         self.cache_max_key_size = cache_max_key_size
@@ -34,25 +37,33 @@ class BaseCacheBackend(object):
             return int(cache_header_age.group(1))
 
     def get_cache_key(self, model, url):
-        """ Cache key format is %(resource_name)s::%(url)s where the URL may be
-          md5 hashed when it exceeds length.  strips white space from cache key as
-           its a control character in memcached.
+        """Cache key format is %(resource_name)s::%(url)s where the URL may be
+        md5 hashed when it exceeds length.  strips white space from cache key
+        as its a control character in memcached.
         """
-        resource_name = model._meta['resource_name']
-        cache_key = "{0}::".format(resource_name)
 
-        if self.cache_max_key_size is not None and (len(cache_key) + len(url)) > self.cache_max_key_size:
+        resource_name = model._meta['resource_name']
+        cache_key = '{0}::'.format(resource_name)
+
+        # Check
+        if (
+                self.cache_max_key_size is not None and
+                (len(cache_key) + len(url)) > self.cache_max_key_size
+        ):
             cache_key += md5(url.encode('utf-8')).hexdigest()
             logger = model._meta['logger']
-            logger.info("Cache key for url {0} exceeds length so hashing to key {1}".format(url, cache_key))
+            logger.info(
+                'Cache key for url %s exceeds length so hashing to key %s',
+                url,
+                cache_key
+            )
         else:
             cache_key += url
 
-        cache_key = cache_key.replace(" ", "")
+        cache_key = cache_key.replace(' ', '')
         return cache_key
 
     def get_timeout(self, response=None):
-
         if response and self.obey_cache_headers:
             header_timeout = self.get_timeout_from_header(response)
             if header_timeout:

--- a/nap/cache/django_cache.py
+++ b/nap/cache/django_cache.py
@@ -1,16 +1,13 @@
-from __future__ import unicode_literals
-from __future__ import absolute_import
 try:
     from django.core.cache import cache
 except ImportError as e:
-    raise ImportError("Error loading django cache module: %s" % e)
+    raise ImportError('Error loading django cache module: {}'.format(e))
 
 
-from .base import BaseCacheBackend
+from nap.cache.base import BaseCacheBackend
 
 
 class DjangoCacheBackend(BaseCacheBackend):
-
     def get(self, key):
         return cache.get(key)
 

--- a/nap/cache/flask_cache.py
+++ b/nap/cache/flask_cache.py
@@ -1,7 +1,7 @@
 try:
     import flask_caching
 except ImportError as e:
-    raise ImportError('Error loading Flask-Caching: %s'.format(e))
+    raise ImportError('Error loading Flask-Caching: {}'.format(e))
 
 
 from nap.cache.base import BaseCacheBackend

--- a/nap/cache/flask_cache.py
+++ b/nap/cache/flask_cache.py
@@ -1,16 +1,13 @@
-from __future__ import unicode_literals
-from __future__ import absolute_import
 try:
     import flask_caching
 except ImportError as e:
-    raise ImportError("Error loading Flask-Caching: %s" % e)
+    raise ImportError('Error loading Flask-Caching: %s'.format(e))
 
 
-from .base import BaseCacheBackend, DEFAULT_TIMEOUT
+from nap.cache.base import BaseCacheBackend
 
 
 class FlaskCacheBackend(BaseCacheBackend):
-
     def __init__(self, app, config=None, **kwargs):
         super(FlaskCacheBackend, self).__init__(**kwargs)
         self.cache = flask_caching.Cache(app, config=config)

--- a/nap/collection.py
+++ b/nap/collection.py
@@ -1,9 +1,8 @@
-from __future__ import unicode_literals
+from collections import UserList
 
-class ListWithAttributes(list):
+
+class ListWithAttributes(UserList):
     def __init__(self, list_vals, extra_data=None):
+        self.extra_data = extra_data if extra_data else {}
 
-        if not extra_data:
-            extra_data = {}
-        super(ListWithAttributes, self).__init__(list_vals)
-        self.extra_data = extra_data
+        super().__init__(list_vals)

--- a/nap/conf.py
+++ b/nap/conf.py
@@ -1,12 +1,9 @@
-from __future__ import unicode_literals
-from __future__ import absolute_import
-"""
-Kudos to mitsuhiko for flask's configuration for inspiring much of this
-"""
+"""Kudos to mitsuhiko for flask's configuration for inspiring much of this."""
 import logging
+from collections import UserDict
 
-from .cache.base import BaseCacheBackend
-from .engine import ResourceEngine
+from nap.cache.base import BaseCacheBackend
+from nap.engine import ResourceEngine
 
 
 DEFAULT_CONFIG = {
@@ -34,12 +31,10 @@ DEFAULT_CONFIG = {
     'headers': {},
     'content_type': 'application/json'
 }
-
 REQUIRED_CONFIG = ('resource_name', 'urls')
 
 
-class NapConfig(dict):
-
+class NapConfig(UserDict):
     def get_request_headers(self, config):
         """
         Figures out a "final" ditionary of arguments to pass to
@@ -88,4 +83,4 @@ class NapConfig(dict):
         # last middleware classes ran
         config['middleware'] += config['auth']
 
-        dict.__init__(self, config)
+        super().__init__(self, **config)

--- a/nap/exceptions.py
+++ b/nap/exceptions.py
@@ -1,14 +1,17 @@
-from __future__ import unicode_literals
-
 class InvalidStatusError(ValueError):
-
-    ERROR_MSG = "Expected status code in %s, got %s at %s"
+    ERROR_MSG = 'Expected status code in {}, got {} at {}'
 
     def __init__(self, valid_statuses, response):
         self.valid_statuses = valid_statuses
         self.response = response
-        msg = self.ERROR_MSG % (valid_statuses, response.status_code, response.url)
-        super(InvalidStatusError, self).__init__(msg)
+
+        msg = self.ERROR_MSG.format(
+            valid_statuses,
+            response.status_code,
+            response.url
+        )
+
+        super().__init__(msg)
 
 
 class EmptyResponseError(Exception):
@@ -20,7 +23,6 @@ class DoesNotExist(Exception):
 
 
 class BadRequestError(InvalidStatusError):
-
     def __init__(self, response, errors):
         self.response = response
         self.errors = errors

--- a/nap/http.py
+++ b/nap/http.py
@@ -1,11 +1,17 @@
-from __future__ import unicode_literals
 import requests
 
 
 class NapResponse(object):
 
-    def __init__(self, content, url, status_code,
-            use_cache=None, headers=None, request_method=None):
+    def __init__(
+            self,
+            content,
+            url,
+            status_code,
+            use_cache=None,
+            headers=None,
+            request_method=None
+    ):
         self.status_code = status_code
         self.content = content
         self.url = url
@@ -17,10 +23,10 @@ class NapResponse(object):
 
     @property
     def use_cache(self):
+        """Use_cache must be explicitely set to False to bypass the cache.
+        This is usually done in the engine classes' get_from_cache method.
         """
-        use_cache must be explicitely set to False to bypass the cache.
-        This is usually done in the engine classes' get_from_cache method
-        """
+
         return self._use_cache is not False
 
     @use_cache.setter
@@ -28,26 +34,27 @@ class NapResponse(object):
         self._use_cache = val
 
 
-class NapRequest(object):
-
-    """
-    A request to send to a nap-modeled API. Primarily used internally within
-    ResourceModel methods.
+class NapRequest:
+    """A request to send to a nap-modeled API. Primarily used internally
+    within ResourceModel methods.
     """
 
     VALID_HTTP_METHODS = ('GET', 'POST', 'PUT', 'DELETE', 'PATCH')
 
-    def __init__(self, method, url, data=None, headers=None, auth=None,
-            *args, **kwargs):
-
+    def __init__(
+            self,
+            method,
+            url,
+            data=None,
+            headers=None,
+            auth=None,
+            **kwargs
+    ):
         self._method = method
         self.url = url
         self.data = data
-        if not headers:
-            headers = {}
-        self.headers = headers
+        self.headers = headers if headers else {}
         self.auth = auth
-        self.extra_args = args
         self.extra_kwargs = kwargs
 
     @property
@@ -58,15 +65,17 @@ class NapRequest(object):
     def method(self, value):
         http_method = value.upper()
         if http_method not in self.VALID_HTTP_METHODS:
-            raise ValueError("Invalid method")
+            raise ValueError('Invalid method')
         self._method = value
 
     def send(self):
-        response = requests.request(self.method, self.url,
+        response = requests.request(
+            self.method,
+            self.url,
             data=self.data,
             headers=self.headers,
             auth=self.auth,
-            *self.extra_args,
-            **self.extra_kwargs)
+            **self.extra_kwargs
+        )
 
         return response

--- a/nap/lookup.py
+++ b/nap/lookup.py
@@ -1,27 +1,25 @@
-"""
-Classes and functions for url resolving
-"""
-from __future__ import unicode_literals
-from __future__ import absolute_import
+"""Classes and functions for url resolving."""
 import re
-from .utils import to_unicode
-import six
+
+from nap.utils import to_unicode
 
 
-class LookupURL(object):
-
-    def __init__(self, url_string, params=None,
-            lookup=True, update=False, create=False, collection=False):
-        """
-        Setup necesary URL meta options
-        """
+class LookupURL:
+    def __init__(
+            self,
+            url_string,
+            params=None,
+            lookup=True,
+            update=False,
+            create=False,
+            collection=False
+    ):
+        """Setup necessary URL meta options."""
 
         #  TODO: should lookup default to False?
 
         self.url_string = url_string
-        if params is None:
-            params = []
-        self.params = params
+        self.params = params if params else []
 
         self.lookup = lookup
         self.update = update
@@ -30,9 +28,7 @@ class LookupURL(object):
 
     @property
     def url_vars(self):
-
-        pattern = r'\%\(([\w_\-]+)\)s'
-        return re.findall(pattern, self.url_string)
+        return re.findall(r'%\(([\w_\-]+)\)s', self.url_string)
 
     @property
     def required_vars(self):
@@ -57,13 +53,13 @@ class LookupURL(object):
         return to_unicode(self.url_string)
 
     def __repr__(self):
-        val = "<%s: %s>" % (self.__class__.__name__, self.__unicode__())
-        # For py2 repr needs to return a non-unicode string and in py3 it's the opposite
-        return val.encode('utf8') if six.PY2 else val
+        val = '<{}: {}>'.format(self.__class__.__name__, self.__unicode__())
+        return val
 
 
 def nap_url(*args, **kwargs):
     return LookupURL(*args, **kwargs)
+
 
 default_lookup_urls = (
     nap_url('%(resource_name)s/', create=True, lookup=False, collection=True),

--- a/nap/middleware.py
+++ b/nap/middleware.py
@@ -1,7 +1,4 @@
-from __future__ import unicode_literals
-
-class BaseMiddleware(object):
-
+class BaseMiddleware:
     def handle_request(self, request):
         return request
 

--- a/nap/serializers.py
+++ b/nap/serializers.py
@@ -1,9 +1,7 @@
-from __future__ import unicode_literals
 import json
 
 
-class BaseSerializer(object):
-
+class BaseSerializer:
     def serialize(self, val_dict):
         raise NotImplementedError
 
@@ -11,12 +9,9 @@ class BaseSerializer(object):
         raise NotImplementedError
 
 
-class JSONSerializer(object):
-
+class JSONSerializer:
     def serialize(self, val_dict):
-
         return json.dumps(val_dict)
 
     def deserialize(self, val_str):
-
         return json.loads(val_str)

--- a/nap/utils.py
+++ b/nap/utils.py
@@ -1,8 +1,6 @@
-from __future__ import unicode_literals
 import itertools
 from operator import itemgetter
-import six
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 
 def handle_slash(url, add_slash=None):
@@ -10,12 +8,12 @@ def handle_slash(url, add_slash=None):
 
     if add_slash and not split[0].endswith('/'):
         if len(split) > 1:
-            url = "%s/?%s" % (split[0], split[1])
+            url = '{}/?{}'.format(split[0], split[1])
         else:
-            url = "%s/" % url
+            url = '{}/'.format(url)
     elif add_slash is False and split[0].endswith('/'):
         if len(split) > 1:
-            url = "%s?%s" % (split[0][:-1], split[1])
+            url = "{}?{}".format(split[0][:-1], split[1])
         else:
             url = split[0][:-1]
 
@@ -23,17 +21,17 @@ def handle_slash(url, add_slash=None):
 
 
 def is_string_like(obj):
-    return isinstance(obj, six.string_types)
+    return isinstance(obj, str)
 
 
 def safe_encode(value):
-    if isinstance(value, six.text_type):
+    if isinstance(value, str):
         return value.encode('utf-8')
     return value
 
 
 def make_url(base_url, params=None, add_slash=None):
-    "Split off in case we need to handle more scrubing"
+    """Split off in case we need to handle more scrubbing."""
 
     base_url = handle_slash(base_url, add_slash)
 
@@ -42,7 +40,7 @@ def make_url(base_url, params=None, add_slash=None):
         # we want to pass in multiple instances of that param key.
         def flatten_params(k, vs):
             if not hasattr(vs, '__iter__') or is_string_like(vs):
-                return ((k, safe_encode(vs)),)
+                return (k, safe_encode(vs)),
             return [(k, safe_encode(v)) for v in vs]
 
         flat_params = [
@@ -52,14 +50,13 @@ def make_url(base_url, params=None, add_slash=None):
 
         # since we can have more than one value for a single key, we use a
         # tuple of two tuples instead of a dictionary
-        params_tuple = tuple(sorted(itertools.chain(*flat_params), key=itemgetter(0)))
+        params_tuple = tuple(
+            sorted(itertools.chain(*flat_params), key=itemgetter(0))
+        )
         param_string = urlencode(params_tuple)
-        base_url = "%s?%s" % (base_url, param_string)
+        base_url = '{}?{}'.format(base_url, param_string)
 
     return base_url
-
-
-__text_fn = str if six.PY3 else unicode
 
 
 def to_unicode(s):
@@ -67,13 +64,13 @@ def to_unicode(s):
         return None
 
     # unicode strings
-    elif isinstance(s, six.text_type):
+    elif isinstance(s, str):
         return s
 
     # non-unicode strings
-    elif isinstance(s, six.binary_type):
-        return __text_fn(s, 'utf-8')
+    elif isinstance(s, bytes):
+        return str(s, 'utf-8')
 
     # non-string types
     else:
-        return __text_fn(s)
+        return str(s)

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
-from __future__ import unicode_literals
-from datetime import datetime
-from setuptools import setup, find_packages
 import io
+from datetime import datetime
 
-version = '%s' % datetime.now().strftime("%Y-%m-%d-%H_%M_%S_%f")
+from setuptools import find_packages, setup
+
+version = '{}'.format(datetime.now().strftime('%Y-%m-%d-%H_%M_%S_%f'))
 setup(
     name='nap',
     version=version,
-    description=('api access modeling and tools'),
-    author="Jacob Burch",
-    author_email="jacobburch@gmail.com",
+    description='api access modeling and tools',
+    author='Jacob Burch',
+    author_email='jacobburch@gmail.com',
     url='https://github.com/jacobb/nap',
     long_description=io.open('README.rst', encoding='utf-8').read(),
     packages=find_packages(),
@@ -19,19 +19,18 @@ setup(
     tests_require=[
         'pytest',
         'pytest-cov',
-        'mock',
         'Django>=1.8.18',
         'Flask>=0.11.1',
         'Flask-Caching>=1.2.0'
     ],
     install_requires=[
-        'requests>=1.2.3', 'six'
+        'requests>=1.2.3'
     ],
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
         'Topic :: Utilities',
     ],
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,7 +9,7 @@ class SampleResourceModel(nap.ResourceModel):
     alt_name = nap.Field(api_name='some_field')
 
     class Meta:
-        root_url = "http://foo.com/v1/"
+        root_url = 'http://foo.com/v1/'
         resource_name = 'note'
         append_urls = (
             nap.lookup.nap_url(r'%(hello)s/%(what)s/'),
@@ -24,7 +24,7 @@ class SampleResourceNoIdModel(nap.ResourceModel):
     alt_name = nap.Field(api_name='some_field')
 
     class Meta:
-        root_url = "http://foo.com/v1/"
+        root_url = 'http://foo.com/v1/'
         resource_name = 'note'
         append_urls = (
             nap.lookup.nap_url(r'%(hello)s/%(what)s/'),
@@ -39,7 +39,7 @@ class SampleResourceNoUpdateModel(nap.ResourceModel):
     alt_name = nap.Field(api_name='some_field')
 
     class Meta:
-        root_url = "http://foo.com/v1/"
+        root_url = 'http://foo.com/v1/'
         resource_name = 'note'
         append_urls = (
             nap.lookup.nap_url(r'%(hello)s/%(what)s/'),
@@ -53,7 +53,7 @@ class AuthorModel(nap.ResourceModel):
     email = nap.Field(default=None)
 
     class Meta:
-        root_url = "http://foo.com/v1/"
+        root_url = 'http://foo.com/v1/'
 
 
 class InMemoryCache(BaseCacheBackend):
@@ -71,6 +71,7 @@ class InMemoryCache(BaseCacheBackend):
     def clear(self):
         self._cache = {}
 
+
 class SampleCacheableResource(nap.ResourceModel):
     title = nap.Field()
     content = nap.Field()
@@ -81,6 +82,8 @@ class SampleCacheableResource(nap.ResourceModel):
         root_url = "http://foo.com/v1/"
         resource_name = 'note'
         append_urls = (
-            nap.lookup.nap_url(r'something/great/', collection=True, lookup=True),
+            nap.lookup.nap_url(
+                r'something/great/', collection=True, lookup=True
+            ),
         )
         cache_backend = InMemoryCache()

--- a/tests/django_settings.py
+++ b/tests/django_settings.py
@@ -11,8 +11,6 @@
 # situations, so it is recommended to run the test suite against as many
 # database backends as possible.  You may want to create a separate settings
 # file for each of the backends you test against.
-from __future__ import unicode_literals
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3'

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,20 +1,15 @@
-from __future__ import unicode_literals
-from __future__ import absolute_import
 from nap import auth
-from .utils import get_nap_request
+from tests.utils import get_nap_request
 
 
-class TestBaseAuthorization(object):
-
+class TestBaseAuthorization:
     def test_dummy_methods(self):
-
         base_auth = auth.BaseAuthorization()
 
         assert base_auth.handle_request('1234') == '1234'
 
 
-class TestHttpAuthorization(object):
-
+class TestHttpAuthorization:
     def test_handle_request(self):
         http_auth = auth.HttpAuthorization(username='user', password='pass')
 
@@ -25,12 +20,12 @@ class TestHttpAuthorization(object):
         assert new_request.auth == ('user', 'pass')
 
 
-class TestFoauthAuthorization(object):
-
+class TestFoauthAuthorization:
     def create_auth(self):
         foauth_auth = auth.FoauthAuthorization(
             email='test@email.com',
-            password='123')
+            password='123'
+        )
 
         return foauth_auth
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,11 +1,9 @@
-from __future__ import unicode_literals
 from nap.collection import ListWithAttributes
 
 
-class TestListWithAttributes(object):
-
+class TestListWithAttributes:
     def test_acts_like_list(self):
-        lwa = ListWithAttributes([1,2,3])
+        lwa = ListWithAttributes([1, 2, 3])
 
         assert len(lwa) == 3
         assert 1 in lwa
@@ -14,6 +12,6 @@ class TestListWithAttributes(object):
 
     def test_extra_data(self):
         ed = {'some_data': 'Hello'}
-        lwa = ListWithAttributes([1,2,3], extra_data=ed)
+        lwa = ListWithAttributes([1, 2, 3], extra_data=ed)
 
         assert lwa.extra_data['some_data'] == ed['some_data']

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from nap.conf import NapConfig, DEFAULT_CONFIG
 from nap.auth import BaseAuthorization
 
@@ -11,7 +10,6 @@ def test_config_defaults():
 
 
 def test_config_override():
-
     new_options = {
         'override_methood': 'PATCH',
         'add_slash': False,
@@ -29,7 +27,6 @@ def test_config_override():
 
 
 def test_auth_added_to_middleware():
-
     conf_dict = {
         'auth': (BaseAuthorization,)
     }

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,28 +1,22 @@
-from __future__ import unicode_literals
-from __future__ import absolute_import
 import json
 import unittest
 from collections import OrderedDict
-
-import pytest
-import mock
+from unittest import mock
 
 import nap
-from nap.http import NapResponse
+import pytest
 from nap.engine import ResourceEngine
-from nap.exceptions import InvalidStatusError, BadRequestError
+from nap.exceptions import BadRequestError, InvalidStatusError
+from nap.http import NapResponse
+from tests import SampleResourceModel
 
-from . import SampleResourceModel
 
-
-class BaseResourceModelTest(object):
-
+class BaseResourceModelTest:
     def get_engine(self):
         engine = ResourceEngine(SampleResourceModel)
         return engine
 
     def get_mock_response(self, **kwargs):
-
         default_kwargs = {
             'status_code': 200,
             'content': '',
@@ -34,16 +28,14 @@ class BaseResourceModelTest(object):
 
 
 class TestResourceModelURLMethods(BaseResourceModelTest):
-
     def test_get_lookup_url(self):
-
         engine = self.get_engine()
 
         with pytest.raises(ValueError):
             engine.get_lookup_url(content='something')
 
         final_uri = engine.get_lookup_url(hello='1', what='2')
-        assert final_uri == "1/2/"
+        assert final_uri == '1/2/'
 
         final_uri_with_params = engine.get_lookup_url(
             hello='1',
@@ -69,51 +61,52 @@ class TestResourceModelURLMethods(BaseResourceModelTest):
             what='wut',
             **test_kwargs
         )
-        assert final_uri_with_params == 'hai/wut/?a_list=5&a_list=4&a_list=3&b=2&c=1'
+        assert final_uri_with_params == (
+            'hai/wut/?a_list=5&a_list=4&a_list=3&b=2&c=1'
+        )
         SampleResourceModel._lookup_urls = []
 
     def test_delete_url(self):
-
         engine = self.get_engine()
         final_uri = engine.get_delete_url(title='1')
-        assert final_uri == "1/"
+        assert final_uri == '1/'
 
     def test_update_url(self):
-
         engine = self.get_engine()
         final_uri = engine.get_delete_url(title='1')
-        assert final_uri == "1/"
+        assert final_uri == '1/'
 
     def test_create_url(self):
-
         engine = self.get_engine()
 
-        prepend_urls = (nap.lookup.nap_url(r'special_create_url/', create=True, lookup=False),)
+        prepend_urls = (
+            nap.lookup.nap_url(
+                r'special_create_url/', create=True, lookup=False
+            ),
+        )
         old_urls = engine.model._meta['urls']
         new_urls = prepend_urls + old_urls
         engine.model._meta['urls'] = new_urls
 
         final_uri = engine.get_create_url()
-        assert final_uri == "special_create_url/"
+        assert final_uri == 'special_create_url/'
 
         engine.model._meta['urls'] = old_urls
 
 
 class TestResourceEngineAccessMethods(BaseResourceModelTest):
-
     def test_get_from_uri(self, skip_cache=False):
-
         engine = self.get_engine()
         fake_dict = {
-            'title': "A fake title",
-            'content': "isnt this neat",
+            'title': 'A fake title',
+            'content': 'isnt this neat',
         }
         with mock.patch('requests.request') as get:
             stubbed_response = mock.Mock()
             stubbed_response.content = json.dumps(fake_dict)
 
             model_root_url = engine.model._meta['root_url']
-            expected_url = "xyz/"
+            expected_url = 'xyz/'
             stubbed_response.url = expected_url
             stubbed_response.status_code = 200
 
@@ -127,7 +120,6 @@ class TestResourceEngineAccessMethods(BaseResourceModelTest):
 
     @mock.patch('nap.engine.ResourceEngine.get_from_cache')
     def test_get_from_uri_skip_cache(self, *mocks):
-
         get_from_cache = mocks[0]
         get_from_cache.return_value = None
 
@@ -148,7 +140,6 @@ class TestResourceEngineAccessMethods(BaseResourceModelTest):
         engine.model._meta['root_url'] = root_url
 
     def test_get(self):
-
         engine = self.get_engine()
         with mock.patch('nap.engine.ResourceEngine.get_from_uri') as g:
             engine.get('/some/uri/')
@@ -158,7 +149,6 @@ class TestResourceEngineAccessMethods(BaseResourceModelTest):
             assert lookup.called
 
     def test_lookup(self):
-
         engine = self.get_engine()
         with mock.patch('nap.engine.ResourceEngine.get_from_uri') as get:
             engine.lookup(hello='hello_test', what='what_test')
@@ -167,7 +157,6 @@ class TestResourceEngineAccessMethods(BaseResourceModelTest):
         SampleResourceModel._lookup_urls = []
 
     def test_lookup_no_valid_urls(self):
-
         engine = self.get_engine()
         from pytest import raises
         with raises(ValueError):
@@ -176,18 +165,25 @@ class TestResourceEngineAccessMethods(BaseResourceModelTest):
         SampleResourceModel._lookup_urls = []
 
     def test_generate_url(self):
-
         engine = self.get_engine()
         rm = engine.model(hello='1', slug='slug')
-        assert engine._generate_url(url_type='create', resource_obj=rm) == 'note/'
+        assert engine._generate_url(
+            url_type='create', resource_obj=rm
+        ) == 'note/'
 
         # assert that keyword arguments take precedence over meta arguments
-        essay_url = rm.objects._generate_url(url_type='create', resource_name='essay')
+        essay_url = rm.objects._generate_url(
+            url_type='create', resource_name='essay'
+        )
         assert essay_url == 'essay/'
 
-        assert rm.objects._generate_url(url_type='update', resource_obj=rm) == 'note/slug/'
+        assert rm.objects._generate_url(
+            url_type='update', resource_obj=rm
+        ) == 'note/slug/'
         # assert that keyword arguments take predecnce over field values
-        new_slug_url = rm.objects._generate_url(url_type='update', slug='new-slug')
+        new_slug_url = rm.objects._generate_url(
+            url_type='update', slug='new-slug'
+        )
         assert new_slug_url == 'note/new-slug/'
 
     def test_validate_get_response(self):
@@ -198,7 +194,6 @@ class TestResourceEngineAccessMethods(BaseResourceModelTest):
             engine.validate_get_response(res)
 
     def test_obj_from_response(self):
-
         engine = self.get_engine()
         res = mock.Mock()
         res_dict = {'title': 'a title', 'content': 'some content'}
@@ -211,9 +206,7 @@ class TestResourceEngineAccessMethods(BaseResourceModelTest):
 
 
 class TestResourceCollectionMethods(BaseResourceModelTest):
-
     def test_collection_field(self):
-
         SampleResourceModel._meta['collection_field'] = 'objects'
         with mock.patch('requests.request') as request:
             r = mock.Mock()
@@ -221,7 +214,7 @@ class TestResourceCollectionMethods(BaseResourceModelTest):
                 'meta': {'something': True},
                 'objects': [
                     {'title': 'a'},
-                    {'title': 'b', 'content': "b's content"},
+                    {'title': 'b', 'content': 'b\'s content'},
                     {'title': 'c'},
                 ]
             }
@@ -258,8 +251,7 @@ class TestResourceCollectionMethods(BaseResourceModelTest):
             engine.validate_collection_response(res)
 
 
-class TestCacheFunctions(object):
-
+class TestCacheFunctions:
     @mock.patch('requests.request')
     @mock.patch('nap.cache.base.BaseCacheBackend.get')
     def test_cached_result(self, *mocks):
@@ -276,14 +268,13 @@ class TestCacheFunctions(object):
         )
         get.return_value = cached_response
         res = SampleResourceModel.objects.get_from_uri('some-url/')
-        assert res.full_url == "some-url/"
-        assert res.title == "hello!"
+        assert res.full_url == 'some-url/'
+        assert res.title == 'hello!'
         assert not req.called
 
     @mock.patch('nap.cache.base.BaseCacheBackend.get')
     @mock.patch('nap.cache.base.BaseCacheBackend.set')
     def test_cache_set_not_called_on_cached_reselt(self, *mocks):
-
         get = mocks[1]
         cache_set = mocks[0]
 
@@ -302,7 +293,6 @@ class TestCacheFunctions(object):
     @mock.patch('nap.engine.ResourceEngine._request')
     @mock.patch('nap.cache.base.BaseCacheBackend.set')
     def test_set_cache_from_response(self, *mocks):
-
         cache_set = mocks[0]
         req = mocks[1]
 
@@ -320,12 +310,13 @@ class TestCacheFunctions(object):
         )
         SampleResourceModel.objects.get_from_uri('some-url/')
 
-        cache_set.assert_called_with(expected_cache_key, response, response=response)
+        cache_set.assert_called_with(
+            expected_cache_key, response, response=response
+        )
 
     @mock.patch('nap.engine.ResourceEngine._request')
     @mock.patch('nap.cache.base.BaseCacheBackend.set')
     def test_set_cache_not_called(self, *mocks):
-
         cache_set = mocks[0]
         req = mocks[1]
 
@@ -337,7 +328,9 @@ class TestCacheFunctions(object):
             request_method='POST',
         )
         req.return_value = response
-        expected_cache_key = SampleResourceModel.objects.cache.get_cache_key(SampleResourceModel, response.url)
+        SampleResourceModel.objects.cache.get_cache_key(
+            SampleResourceModel, response.url
+        )
         obj = SampleResourceModel(title='some-url/')
         obj.save()
 
@@ -346,7 +339,6 @@ class TestCacheFunctions(object):
     @mock.patch('requests.request')
     @mock.patch('nap.cache.base.BaseCacheBackend.get')
     def test_invalid_cache_result_found(self, mock_get, mock_request):
-
         cached_response = 'Invalid cache value - should be a nap response'
         mock_get.return_value = cached_response
 
@@ -358,19 +350,17 @@ class TestCacheFunctions(object):
         )
         mock_request.return_value = response
 
-        res = SampleResourceModel.objects.get_from_uri('some-url/')
+        SampleResourceModel.objects.get_from_uri('some-url/')
         assert mock_request.called
 
 
 class TestResourceEngineWriteMethods(BaseResourceModelTest, unittest.TestCase):
-
     headers = {'content-type': 'application/json'}
 
     def tearDown(self):
         SampleResourceModel._lookup_urls = []
 
     def dont_test_write_url(self):
-
         dm = SampleResourceModel(
             title='expected_title',
             content='Blank Content')
@@ -391,17 +381,22 @@ class TestResourceEngineWriteMethods(BaseResourceModelTest, unittest.TestCase):
             put.return_value = r
             SampleResourceModel.objects.update(dm)
             data = SampleResourceModel.objects.serialize(dm, for_read=True)
-            put.assert_called_with('PUT', "http://foo.com/v1/expected_title/",
-                data=data, headers=self.headers, auth=None)
+            put.assert_called_with(
+                'PUT',
+                'http://foo.com/v1/expected_title/',
+                data=data,
+                headers=self.headers,
+                auth=None
+            )
         SampleResourceModel._lookup_urls = []
 
     def test_create(self):
-
         # add a lookup url to ensure it doesn't get used
         dm = SampleResourceModel(
             title='expected_title',
             content='Blank Content',
-            slug='some_slug')
+            slug='some_slug'
+        )
         with mock.patch('requests.request') as post:
             r = mock.Mock()
             r.content = ''
@@ -410,16 +405,18 @@ class TestResourceEngineWriteMethods(BaseResourceModelTest, unittest.TestCase):
             post.return_value = r
             SampleResourceModel.objects.create(dm)
             data = SampleResourceModel.objects.serialize(dm, for_read=True)
-            post.assert_called_with('POST', "http://foo.com/v1/note/",
-                data=data, headers=self.headers, auth=None)
+            post.assert_called_with(
+                'POST',
+                'http://foo.com/v1/note/',
+                data=data,
+                headers=self.headers,
+                auth=None
+            )
         SampleResourceModel._lookup_urls = []
 
     def test_write_with_no_lookup_url(self):
-
-        from pytest import raises
-
         dm = SampleResourceModel(content='what')
-        with raises(ValueError):
+        with pytest.raises(ValueError):
             SampleResourceModel.objects.update(dm)
 
     def test_handle_update_response(self):
@@ -437,7 +434,7 @@ class TestResourceEngineWriteMethods(BaseResourceModelTest, unittest.TestCase):
         engine = self.get_engine()
 
         with mock.patch('nap.engine.ResourceEngine.obj_from_response') as ofr:
-            ofr.side_effect = ValueError("foo")
+            ofr.side_effect = ValueError('foo')
             obj = engine.handle_update_response(response)
             # assert ofr.called
 
@@ -469,7 +466,7 @@ class TestResourceEngineWriteMethods(BaseResourceModelTest, unittest.TestCase):
         engine = self.get_engine()
 
         with mock.patch('nap.engine.ResourceEngine.obj_from_response') as ofr:
-            ofr.side_effect = ValueError("foo")
+            ofr.side_effect = ValueError('foo')
             obj = engine.handle_create_response(response)
             # assert ofr.called
 
@@ -516,7 +513,6 @@ class TestResourceEngineWriteMethods(BaseResourceModelTest, unittest.TestCase):
     @mock.patch('nap.engine.ResourceEngine.handle_delete_response')
     @mock.patch('nap.engine.ResourceEngine._request')
     def test_delete(self, *mocks):
-
         handle_delete = mocks[1]
         validate_delete = mocks[2]
         engine = self.get_engine()
@@ -526,7 +522,6 @@ class TestResourceEngineWriteMethods(BaseResourceModelTest, unittest.TestCase):
         assert validate_delete.called
 
     def test_validate_delete_response(self):
-
         engine = self.get_engine()
         res = mock.Mock()
         res.status_code = 500
@@ -545,6 +540,7 @@ class TestResourceEngineWriteMethods(BaseResourceModelTest, unittest.TestCase):
 
         assert obj is None
 
+
 def test_modify_request():
     new_headers = {'test-header': '123'}
     default_args = SampleResourceModel._meta['default_request_args']
@@ -557,9 +553,11 @@ def test_modify_request():
         r.content = '{}'
         r.status_code = 200
         post.return_value = r
-        SampleResourceModel.objects.modify_request(headers=new_headers).filter()
+        SampleResourceModel.objects.modify_request(
+            headers=new_headers
+        ).filter()
         post.assert_called_with(
-            'GET', "http://foo.com/v1/note/",
+            'GET', 'http://foo.com/v1/note/',
             data=None,
             headers=new_headers,
             auth=None
@@ -573,7 +571,7 @@ def test_modify_request():
         post2.return_value = r
         SampleResourceModel.objects.filter()
         post2.assert_called_with(
-            'GET', "http://foo.com/v1/note/",
+            'GET', 'http://foo.com/v1/note/',
             data=None,
             headers=default_args['headers'],
             auth=None

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,4 @@
-from __future__ import unicode_literals
-import mock
+from unittest import mock
 
 from nap.exceptions import InvalidStatusError, BadRequestError
 
@@ -8,13 +7,16 @@ def test_invalid_status():
     statuses = (200, 201)
     response = mock.Mock()
     response.status_code = 404
-    response.url = "naprulez.org"
+    response.url = 'naprulez.org'
     e = InvalidStatusError(statuses, response)
     try:
         raise e
     except InvalidStatusError as e:
-        expected = InvalidStatusError.ERROR_MSG % (statuses, 404, "naprulez.org")
+        expected = InvalidStatusError.ERROR_MSG.format(
+            statuses, 404, 'naprulez.org'
+        )
         assert str(e) == expected
+
 
 def test_bad_request():
     response = mock.Mock()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,25 +1,28 @@
-from __future__ import unicode_literals
-from __future__ import absolute_import
 import datetime
-import pytest
 from decimal import Decimal
 
-from . import AuthorModel
-from nap.fields import (Field, ResourceField, ListField,
-        DictField, DateTimeField, DateField, DecimalField, SimpleListField)
+import pytest
+from nap.fields import (
+    DateField,
+    DateTimeField,
+    DecimalField,
+    DictField,
+    Field,
+    ListField,
+    ResourceField,
+    SimpleListField
+)
+from tests import AuthorModel
 
 
-class TestFields(object):
-
+class TestFields:
     def test_field(self):
-
         field = Field(default='xyz')
 
         assert field.get_default() == 'xyz'
         assert field.scrub_value('123') == '123'
 
     def test_readonly(self):
-
         field = Field()
         assert field.readonly is False
 
@@ -33,7 +36,6 @@ class TestFields(object):
         assert pk_readonly_field.readonly is False
 
     def test_resource_field(self):
-
         field = ResourceField(AuthorModel)
 
         assert field.scrub_value('') is None
@@ -63,12 +65,12 @@ class TestFields(object):
                 'email': 'elitist@gmail.com',
             },
             {
-                'name': "Bob",
+                'name': 'Bob',
                 'email': None
             },
             {
-                'name': "Jane",
-                "email": "jane@doe.com",
+                'name': 'Jane',
+                'email': 'jane@doe.com',
             }
         ]
         resource_list = field.scrub_value(author_dict_list)
@@ -108,7 +110,7 @@ class TestFields(object):
                 'email': 'elitist@gmail.com',
             },
             'ghost_writer': {
-                'name': "Bob",
+                'name': 'Bob',
                 'email': None,
             },
         }
@@ -124,7 +126,6 @@ class TestFields(object):
         assert new_author_dict_dict == author_dict_dict
 
     def test_datetime_field(self):
-
         field = DateTimeField()
 
         dt_str = '2012-08-21T22:30:14'
@@ -145,8 +146,7 @@ class TestFields(object):
         assert field.descrub_value(None) is None
 
     def test_datetime_field_new_dt_format(self):
-
-        boring_format = "%Y-%m-%d %H:%M:%S"
+        boring_format = '%Y-%m-%d %H:%M:%S'
         field = DateTimeField(dt_format=boring_format)
 
         dt_str = '2010-06-02 16:30:06'
@@ -155,9 +155,9 @@ class TestFields(object):
         assert field.scrub_value(dt_str) == expected_dt
         assert field.descrub_value(expected_dt) == dt_str
 
-        field = DateTimeField(dt_formats=(boring_format, "%Y-%m-%dT%H:%M:%S"))
+        field = DateTimeField(dt_formats=(boring_format, '%Y-%m-%dT%H:%M:%S'))
         dt_str2 = '2010-06-02T16:30:06'
-        bad_string = "2010/06/02 16:30 06 seconds"
+        bad_string = '2010/06/02 16:30 06 seconds'
         expected_dt = datetime.datetime(year=2010, month=6, day=2,
                                         hour=16, minute=30, second=6)
         assert field.scrub_value(dt_str) == expected_dt
@@ -173,7 +173,6 @@ class TestFields(object):
         assert field.descrub_value(expected_dt) == dt_str
 
     def test_date_field(self):
-
         field = DateField()
 
         dt_str = '2012-08-21'
@@ -182,14 +181,12 @@ class TestFields(object):
         assert field.descrub_value(expected_dt) == dt_str
 
     def test_empty_date_field(self):
-
         field = DateField()
         assert field.scrub_value(None) is None
         assert field.descrub_value(None) is None
 
     def test_date_field_new_dt_format(self):
-
-        american_format = "%m/%d/%Y"
+        american_format = '%m/%d/%Y'
         field = DateField(dt_format=american_format)
 
         dt_str = '08/21/2012'
@@ -197,9 +194,9 @@ class TestFields(object):
         assert field.scrub_value(dt_str) == expected_dt
         assert field.descrub_value(expected_dt) == dt_str
 
-        field = DateField(dt_formats=(american_format, "%Y-%m-%d"))
+        field = DateField(dt_formats=(american_format, '%Y-%m-%d'))
         dt_str2 = '08/21/2012'
-        bad_string = "2010~06~02"
+        bad_string = '2010~06~02'
         expected_dt = datetime.date(year=2012, month=8, day=21)
         assert field.scrub_value(dt_str) == expected_dt
         assert field.scrub_value(dt_str2) == expected_dt
@@ -208,12 +205,11 @@ class TestFields(object):
         with pytest.raises(ValueError):
             field.scrub_value(bad_string)
 
-
     def test_simple_list_field(self):
         field = SimpleListField()
 
         # existing list returns the same list
-        assert [1,2,3,4] == field.scrub_value([1,2,3,4])
+        assert [1, 2, 3, 4] == field.scrub_value([1, 2, 3, 4])
 
         # existing tuple
         assert [123] == field.scrub_value(123,)
@@ -228,7 +224,7 @@ class TestFields(object):
 
         # ---- descrub
         # existing list returns the same list
-        assert [1,2,3,4] == field.descrub_value([1,2,3,4])
+        assert [1, 2, 3, 4] == field.descrub_value([1, 2, 3, 4])
 
         # existing tuple
         assert [123] == field.descrub_value(123,)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,15 +1,12 @@
-from __future__ import unicode_literals
 import pytest
 
 from nap.http import NapRequest, NapResponse
 
 
-class TestRequestMethods(object):
-
+class TestRequestMethods:
     def test_invalid_http_method(self):
-
         # ...for now
-        invalid_method = "TARDIS"
+        invalid_method = 'TARDIS'
 
         r = NapRequest('badurl.com/', 'POST')
 
@@ -17,8 +14,7 @@ class TestRequestMethods(object):
             r.method = invalid_method
 
 
-class TestNapResponse(object):
-
+class TestNapResponse:
     def test_default_headers(self):
         res = NapResponse('content', 'naprulez.org', 200)
 

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,13 +1,10 @@
-from __future__ import unicode_literals
 from nap.lookup import LookupURL
 
 
-class TestLookupURL(object):
-
+class TestLookupURL:
     url_string = r'xx%(hello)s%(what)s'
 
     def test_init(self):
-
         lookup_url = LookupURL(self.url_string, ('extra',))
 
         assert lookup_url.url_string == self.url_string
@@ -27,7 +24,6 @@ class TestLookupURL(object):
         assert 'extra' in lookup_url.required_vars
 
     def test_multiple_extra_params(self):
-
         lookup_url = LookupURL(self.url_string)
 
         url, extra = lookup_url.match(hello='hi', what='who', extra_extra=['one', 'two'])

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,28 +1,23 @@
-from __future__ import unicode_literals
-from __future__ import absolute_import
 import json
+from unittest import mock
 
-import mock
-
-from . import SampleResourceModel
 from nap.middleware import BaseMiddleware
+from tests import SampleResourceModel
 
 
 class TestMiddleware(BaseMiddleware):
-
     def handle_request(self, request):
-        request = super(TestMiddleware, self).handle_request(request)
+        request = super().handle_request(request)
         request.headers.update({'fake_header': 'fake_value'})
         return request
 
     def handle_response(self, request, response):
-        response = super(TestMiddleware, self).handle_response(request, response)
+        response = super().handle_response(request, response)
         response.headers.update({'fake_header': 'fake_response_value'})
         return response
 
 
-class TestBaseMiddleware(object):
-
+class TestBaseMiddleware:
     def get_rm(self, **kwargs):
         rm = SampleResourceModel(**kwargs)
         rm._meta['middleware'] += TestMiddleware(),
@@ -32,8 +27,8 @@ class TestBaseMiddleware(object):
     def test_handle_request(self):
         rm = self.get_rm()
         fake_dict = {
-            'title': "A fake title",
-            'content': "isnt this neat",
+            'title': 'A fake title',
+            'content': 'isnt this neat',
         }
         with mock.patch('requests.request') as r:
             stubbed_response = mock.Mock()
@@ -50,8 +45,8 @@ class TestBaseMiddleware(object):
     def test_handle_response(self):
         rm = self.get_rm()
         fake_dict = {
-            'title': "A fake title",
-            'content': "isnt this neat",
+            'title': 'A fake title',
+            'content': 'isnt this neat',
         }
         with mock.patch('requests.request') as r:
             stubbed_response = mock.Mock()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,19 +1,17 @@
-from __future__ import unicode_literals
-from __future__ import absolute_import
+from unittest import mock
+
 import nap
-from nap.exceptions import EmptyResponseError
-
-import mock
 import pytest
+from nap.exceptions import EmptyResponseError
+from tests import (
+    SampleResourceModel,
+    SampleResourceNoIdModel,
+    SampleResourceNoUpdateModel
+)
 
-from . import (SampleResourceModel, SampleResourceNoIdModel,
-    SampleResourceNoUpdateModel)
 
-
-class TestResourceModelCreation(object):
-
+class TestResourceModelCreation:
     def test_mapping_to_fields(self):
-
         dm = SampleResourceModel(title='a', content='b')
 
         assert dm.title == 'a'
@@ -21,7 +19,6 @@ class TestResourceModelCreation(object):
         assert len(dm.extra_data) == 0
 
     def test_extra_data(self):
-
         dm = SampleResourceModel(title='a', note='b', z='c')
 
         assert dm.extra_data['z'] == 'c'
@@ -33,30 +30,28 @@ class TestResourceModelCreation(object):
         assert dm.alt_name == 'c'
 
     def test_meta_attached(self):
-
         class SampleMetaDataModel(nap.ResourceModel):
             class Meta:
                 resource_name = 'bob'
-                root_url = "http://foo.com/v1/"
+                root_url = 'http://foo.com/v1/'
 
         dm = SampleMetaDataModel()
 
         assert dm._meta['resource_name'] == 'bob'
-        assert dm._meta['root_url'] == "http://foo.com/v1/"
+        assert dm._meta['root_url'] == 'http://foo.com/v1/'
 
     def test_override_root_url(self):
-
-        different_url = "http://www.differenturl.com/v1/"
+        different_url = 'http://www.differenturl.com/v1/'
         dm = SampleResourceModel(root_url=different_url)
         assert dm._root_url == different_url
 
 
 class TestResourceSave(object):
-
     def test_save(self):
         dm = SampleResourceModel(
             title=None,
-            content='Blank Content')
+            content='Blank Content'
+        )
         with mock.patch('nap.engine.ResourceEngine.create') as create:
             dm.save()
             assert create.called
@@ -72,7 +67,8 @@ class TestResourceSave(object):
     def test_save_no_update_from_write(self):
         dm = SampleResourceNoUpdateModel(
             title=None,
-            content='Blank Content')
+            content='Blank Content'
+        )
         with mock.patch('nap.engine.ResourceEngine.create') as create:
             create.return_value = None
             dm.save()
@@ -84,8 +80,7 @@ class TestResourceSave(object):
             assert update.called
 
 
-class TestResourceID(object):
-
+class TestResourceID:
     def test_resource_id_get(self):
         dm = SampleResourceModel(
             title='expected_title',
@@ -106,7 +101,7 @@ class TestResourceID(object):
             slug='some-slug',
         )
 
-        dm.resource_id = "Hello"
+        dm.resource_id = 'Hello'
         assert dm.resource_id is None
 
     def test_resource_id_set(self):
@@ -121,9 +116,7 @@ class TestResourceID(object):
 
 
 class TestReourceEtcMethods(object):
-
     def test_repr(self):
-
         dm = SampleResourceModel(slug='some-slug')
         assert str(dm) == '<SampleResourceModel: some-slug>'
 
@@ -143,18 +136,16 @@ class TestReourceEtcMethods(object):
     def test_cache_key_method(self):
         dm = SampleResourceModel(slug='some-slug')
 
-        assert dm.cache_key == "note::http://foo.com/v1/note/some-slug/"
+        assert dm.cache_key == 'note::http://foo.com/v1/note/some-slug/'
 
 
-class TestResourceAuth(object):
-
+class TestResourceAuth:
     def test_meta_set(self):
         # SampleResourceModel
         pass
 
 
-class TestResourceShortcutMethods(object):
-
+class TestResourceShortcutMethods:
     def get_resource_obj(self, **kwargs):
         defaults = {
             'slug': 'some-slug',

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,24 +1,19 @@
-from __future__ import unicode_literals
 import json
 
 import pytest
-
 from nap.serializers import BaseSerializer, JSONSerializer
 
 
 def test_base_serializer():
-    from pytest import raises
-
     serializer = BaseSerializer()
     with pytest.raises(NotImplementedError):
         serializer.serialize({})
 
-    with raises(NotImplementedError):
+    with pytest.raises(NotImplementedError):
         serializer.deserialize('{}')
 
 
-class TestJSONSerializer(object):
-
+class TestJSONSerializer:
     def get_serializer(self):
         return JSONSerializer()
 
@@ -35,7 +30,6 @@ class TestJSONSerializer(object):
         assert dict_from_json == sample_dict
 
     def test_deserialize(self):
-
         serializer = self.get_serializer()
 
         json_str = '{"a": 1, "b": 2}'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,73 +1,72 @@
-from __future__ import unicode_literals
-
 from nap.utils import make_url, is_string_like, handle_slash
 
+
 def test_url_is_normalized():
-    base_url = "https://example.com/path/"
+    base_url = 'https://example.com/path/'
     params = {'two': [3, 2], 'one': 1}
-    expected_normalized_url = "https://example.com/path/?one=1&two=3&two=2"
+    expected_normalized_url = 'https://example.com/path/?one=1&two=3&two=2'
 
     actual_normalized_url = make_url(base_url, params)
     assert actual_normalized_url == expected_normalized_url
+
 
 def test_partial_url_is_normalized():
-    base_url = "https://foo.bar.example.com"
+    base_url = 'https://foo.bar.example.com'
     params = {}
-    expected_normalized_url = "https://foo.bar.example.com"
+    expected_normalized_url = 'https://foo.bar.example.com'
 
     actual_normalized_url = make_url(base_url, params)
     assert actual_normalized_url == expected_normalized_url
 
+
 def test_url():
-    url = make_url("http://www.naprulez.org/", params={'x': '1'})
-    assert url == "http://www.naprulez.org/?x=1"
+    url = make_url('http://www.naprulez.org/', params={'x': '1'})
+    assert url == 'http://www.naprulez.org/?x=1'
 
 
 def test_no_params():
-    url = make_url("http://www.naprulez.org/")
-    assert url == "http://www.naprulez.org/"
+    url = make_url('http://www.naprulez.org/')
+    assert url == 'http://www.naprulez.org/'
 
 
 def test_multiple_params():
-    url = make_url("http://www.naprulez.org/", params={'x': ['1', '2']})
-    assert url == "http://www.naprulez.org/?x=1&x=2"
+    url = make_url('http://www.naprulez.org/', params={'x': ['1', '2']})
+    assert url == 'http://www.naprulez.org/?x=1&x=2'
 
 
 def test_add_slash():
-    url = "http://www.naprulez.org"
-    assert make_url(url, add_slash=True) == "http://www.naprulez.org/"
-    assert make_url(url, add_slash=False) == "http://www.naprulez.org"
-    assert make_url(url, params={'x': 1}) == "http://www.naprulez.org?x=1"
+    url = 'http://www.naprulez.org'
+    assert make_url(url, add_slash=True) == 'http://www.naprulez.org/'
+    assert make_url(url, add_slash=False) == 'http://www.naprulez.org'
+    assert make_url(url, params={'x': 1}) == 'http://www.naprulez.org?x=1'
 
-    url_s = "http://www.naprulez.org/"
-    assert make_url(url_s, add_slash=True) == "http://www.naprulez.org/"
-    assert make_url(url_s, add_slash=False) == "http://www.naprulez.org"
-    assert make_url(url_s, params={'x': 1}) == "http://www.naprulez.org/?x=1"
+    url_s = 'http://www.naprulez.org/'
+    assert make_url(url_s, add_slash=True) == 'http://www.naprulez.org/'
+    assert make_url(url_s, add_slash=False) == 'http://www.naprulez.org'
+    assert make_url(url_s, params={'x': 1}) == 'http://www.naprulez.org/?x=1'
 
 
 def test_stringlike():
-
     assert is_string_like('hello') is True
     assert is_string_like('hello') is True
     assert is_string_like(123) is False
 
 
 def test_unicode():
-    url = make_url("http://www.naprulez.org/", params={'x': u'\u0414'})
-    assert url == "http://www.naprulez.org/?x=%D0%94"
+    url = make_url('http://www.naprulez.org/', params={'x': u'\u0414'})
+    assert url == 'http://www.naprulez.org/?x=%D0%94'
 
 
-class TestHandleTest(object):
-
+class TestHandleTest:
     def test_has_get_params(self):
-        uri = "something.com?q=bob&x=sue"
+        uri = 'something.com?q=bob&x=sue'
         new_uri = handle_slash(uri, add_slash=True)
-        assert new_uri == "something.com/?q=bob&x=sue"
+        assert new_uri == 'something.com/?q=bob&x=sue'
 
         new_uri = handle_slash(uri)
-        assert new_uri == "something.com?q=bob&x=sue"
+        assert new_uri == 'something.com?q=bob&x=sue'
 
     def has_get_params_ends_in_slash(self):
-        uri = "something.com/?q=bob&x=sue"
+        uri = 'something.com/?q=bob&x=sue'
         new_uri = handle_slash(uri, add_slash=False)
-        assert new_uri == "something.com?q=bob&x=sue"
+        assert new_uri == 'something.com?q=bob&x=sue'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,13 +1,16 @@
-from __future__ import unicode_literals
 from nap.http import NapRequest
 
 
-def get_nap_request(method='GET', url='http://www.foo.com',
-        headers=None, auth=None, *args, **kwargs):
+def get_nap_request(
+        method='GET',
+        url='http://www.foo.com',
+        headers=None,
+        auth=None,
+        *args,
+        **kwargs
+):
+    """Fake a NapRequest."""
 
-    """
-    Fake a NapRequest
-    """
     request = NapRequest(method, url, headers, auth, *args, **kwargs)
 
     return request


### PR DESCRIPTION
Nap codebase migrated to Python 3.
What's done:

1. Dropped six & mock module (mock already in standard library in Python 3).
2. Implemented various fixes of PEP 8, redundant code usage.
3. Fixed small bugs, typos, dropped some unused code.
4. For custom classes that based on `dict`, `list` used `UserList` and `UserDict`, it's a better approach. The main reason why it’s preferable to subclass from `UserDict/UserList` rather than from `dict/list`
is that the built-in has some implementation shortcuts that end up forcing us to override
methods that we can just inherit from `UserDict/UserList` with no problems.